### PR TITLE
Temporary fix USWDS default variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/18F/cg-style#readme",
   "dependencies": {
-    "uswds": "git+https://git@github.com/18F/web-design-standards.git#v0.9.x"
+    "uswds": "git+https://git@github.com/18F/web-design-standards.git#952-override_variables"
   },
   "devDependencies": {
     "node-sass": "^3.4.2",


### PR DESCRIPTION
This temporarily changes the USWDS dependency to my own branch so
that variables can be override. More information on the problem here:
https://github.com/18F/web-design-standards/issues/952

Can be reverted back when this is complete:
https://github.com/18F/web-design-standards/pull/953.
