### PR TITLE
Override disclaimer

### DIFF
--- a/css/cg_style.css
+++ b/css/cg_style.css
@@ -2457,3 +2457,6 @@ p + h5 {
 .title_bar-title {
   color: #ffffff;
   font-size: 1rem; }
+
+.usa-disclaimer {
+  font-size: 0.9rem; }

--- a/css/cg_style.scss
+++ b/css/cg_style.scss
@@ -10,3 +10,5 @@
 @import "../src/css/components/nav.scss";
 @import "../src/css/components/sidenav.scss";
 @import "../src/css/components/title_bar.scss";
+
+@import "../src/css/override_components.scss";

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -1,0 +1,6 @@
+
+.usa-disclaimer {
+  // Requires being overridden because uswds sets a different root font-size on
+  // <html> which effects all rem units.
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
Required to be overridden because of font sizes set on uswds.
