### PR TITLE
Fixed firefox layout issues and pre issues

### DIFF
--- a/css/cg_style.css
+++ b/css/cg_style.css
@@ -2286,6 +2286,10 @@ form input[type="submit"] {
   src: url("../fonts/merriweather-italic-webfont.eot");
   src: url("../fonts/merriweather-italic-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/merriweather-italic-webfont.woff2") format("woff2"), url("../fonts/merriweather-italic-webfont.woff") format("woff"), url("../fonts/merriweather-italic-webfont.ttf") format("truetype"); }
 
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word; }
+
 table {
   border-collapse: collapse;
   border-spacing: 0; }
@@ -2883,11 +2887,12 @@ blockquote {
   .section-dark:before {
     background-image: url("../img/chevron-top.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     content: '';
     display: block;
-    height: 5rem;
+    height: 4.865rem;
     position: absolute;
-    top: -5rem;
+    top: -4.865rem;
     width: 100%; }
 
 .section-bg-parent {
@@ -2924,36 +2929,31 @@ blockquote {
   .section-light:before {
     background-image: url("../img/chevron-bottom.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     content: '';
     display: block;
-    height: 5rem;
+    height: 4.865rem;
     position: absolute;
-    top: -5rem;
+    top: -4.865rem;
     width: 100%; }
 
 .section-chevron_alt.section-chevron_alt {
-  padding-bottom: 6.5rem;
-  /*
-  &:not(:first-child) {
-    &:before {
-      display: none !important;
-    }
-  }
-  */ }
+  padding-bottom: 6.5rem; }
   .section-chevron_alt.section-chevron_alt:not(.section-first) {
     background-color: #1F2C38;
     margin-top: -4.5rem;
-    padding-top: 5rem; }
+    padding-top: 4.865rem; }
   .section-chevron_alt.section-chevron_alt:not(.section-first):before {
     background-image: url("../img/chevron-top-inverse.svg");
-    top: -5rem; }
+    top: -4.865rem; }
   .section-chevron_alt.section-chevron_alt:after {
     background-image: url("../img/chevron-bottom-inverse.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     bottom: 0rem;
     content: '';
     display: block;
-    height: 5rem;
+    height: 4.865rem;
     position: absolute;
     width: 100%; }
   .section-chevron_alt.section-chevron_alt + .section-middle {

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -3,5 +3,6 @@
 @import "base/global";
 @import "base/form";
 @import "base/fonts";
+@import "base/formatted";
 @import "base/table";
 @import "base/typography";

--- a/src/css/base/formatted.scss
+++ b/src/css/base/formatted.scss
@@ -1,0 +1,5 @@
+
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/src/css/components/section.scss
+++ b/src/css/components/section.scss
@@ -1,4 +1,6 @@
 
+$chevron_size: 4.865rem;
+
 .section {
   padding-bottom: 12.5rem;
   padding-top: 2.75rem;
@@ -39,11 +41,12 @@
   &:before {
     background-image: url("../img/chevron-top.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     content: '';
     display: block;
-    height: 5rem;
+    height: $chevron_size;
     position: absolute;
-    top: -5rem;
+    top: -$chevron_size;
     width: 100%;
   }
 }
@@ -92,11 +95,12 @@
   &:before {
     background-image: url("../img/chevron-bottom.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     content: '';
     display: block;
-    height: 5rem;
+    height: $chevron_size;
     position: absolute;
-    top: -5rem;
+    top: -$chevron_size;
     width: 100%;
   }
 }
@@ -107,23 +111,24 @@
   &:not(.section-first) {
     background-color: $color-primary-darkest;
     margin-top: -4.5rem;
-    padding-top: 5rem;
+    padding-top: $chevron_size;
   }
 
   &:not(.section-first) {
     &:before {
       background-image: url("../img/chevron-top-inverse.svg");
-      top: -5rem;
+      top: -$chevron_size;
     }
   }
 
   &:after {
     background-image: url("../img/chevron-bottom-inverse.svg");
     background-repeat: no-repeat;
+    background-size: 100% 100%;
     bottom: 0rem;
     content: '';
     display: block;
-    height: 5rem;
+    height: $chevron_size;
     position: absolute;
     width: 100%;
   }


### PR DESCRIPTION
Problem 1: the chevrons weren't expanding in height correctly. This was
fixed by setting a more specific size on them and setting
background-size to 100%. Note: I'm not sure the more specific size
mattered.

Problem 2: pre text on the docs was overflowing and not wrapping.
