### PR TITLE
Attempt at configuring a travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 2.2.3
 before_install:
+- nvm install 4.2.3
 - npm install
 - npm install gulp-cli
 - cd ./node_modules/uswds && npm install && gulp no-test build && cd ../../

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: ruby
+rvm:
+- 2.2.3
+before_install:
+- npm install
+- npm install gulp-cli
+- cd ./node_modules/uswds && npm install && gulp no-test build && cd ../../
+- npm run build
+- bundle config local.cloudgov-style ./gem/
+install:
+- bundle install
+- bundle config local.cloudgov-style ./gem/
+script: bundle exec jekyll build
+after_script:
+- gem install percy-cli
+- percy snapshot _site/
+branches:
+  only:
+  - master
+  - 18f-pages
+deploy:
+  provider: npm
+  on:
+    branch: master
+    tags: true
+  api_key:
+    secure: oyOysSf8T5ueZpaY0+HOqx6Suq/LONSoWI51qagw7Mjacn7KVn/vZtL5DtFn/E1SuXuPDmcTlkHZbDZhh52Kp0uWwB3YVcTKyps71glV9b2KUbKXa8J00Ml3sgK6sjVS9d68/rAUWfKET1+KJm5mQp352//Zuy+cnCX5bcDqzKh6qYOqoiWlKykc0QvoGu8FibeDvKwKUZCrFzecreX+EyWwAi8SvIZz7pgx8X/Q7i6UZAEmSSdY1zZw8mysf13Fk+xza7pJ5pHC++lOQ1RKEmiZSwa6DfSRQfpwxJuydNK2dZv/4b4gaya0/nW50Icpl/1NlPM7AG1lHKrUELOW886yeJ8TWy4kC3MjZD/zXQQNhwiBiH2XKNiUb7RNq/wyTmSJ4WdrxPAVWp1bItLoWNKYnPxc1uf+iGdAIsYsD8dtm2N38R63J+OaUfg3p93/042j3SOUN9HqSv+x2OnICT8t1ziPBEwzcT+BwSa4JXzCXABTMaoERSZOy9rXDCxVkIf/KKf0FajqcOAkEMQj+O/lnJ16qGKVVd9PAcUDW19RLdhtgV6I9qBkgbdCZLY4Bajil4G6UylpYcZpnYxKUMlL1QGYxSeoARe9qP7VKJ3Lsw7mRhBXUo/t1BTolIICi3xx2NWuwDqxWN9OKObHhs+vWLLuhhFOLBxnqJKykxA=
+env:
+  global:
+    secure: NjAkBaViz8sUM0ChzQG5lR9ty7e6xYA3arFeQ3gVrlXwLMNJG6oN3dUKu2LjCHNIm4eTpM9EtR1ra+HwVt3BK7OGl+ebbHcROLPot1mCL8w8NW/bREW0KfZ1oq7wFdzSpinDZOS1ezfVMW+hah+rDVHNsiHoMq9wCNyThBiGGx55MOIkBmwJuJDBjuTTePmwOiRsFT6YWe5e3M5Z8xlzQjzaPN8PmxUv+kI8TXDUiFJ1018CZK7hUwQEXvcAQYlhvzPJ3FxnzIqdcF7UoGU8AFeqRZMy0DcWkNI5rMcWq0iqR0Jm5eUbB30S3WVko8wBYpwGKhQZl3lROzNj0eAwj0KwSeahDpfzJ+9SA5WDJDJ+IS0peed6n82DwuW39hVLf/aJo6SQEBY/QMklZ0LrDmq5AGl9vrSfE0nuxEs2TUyz9mkeTkrkMe6QhIe09NTrPBSN64gtg+oGl7Il1sut+xqJbBU2jvDMDmj+7nk3kA2ziX+LhWY/62ZQvljyntUIhKVhxkxBR55K09dSVZGZtx8OX/L3kWK527HUW5vYcb4fZhnmm1+v2aPpWr64me+RIUwddJLwDY0l+Ui22TwpcdO5TpnUKDLSOs4vRUuBpjRsu2WrEhwZPx2fxRLX4ZZhvQkSl5BlcXJ13lJjwVBc9jW2RouFdkQR3R0I1gePiW4=

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cg-style",
   "version": "0.1.0",
   "description": "The global style of cloud.gov",
-  "main": "dist/index.js",
+  "main": "js/cg-style.js",
   "scripts": {
     "clean": "rm -rf css/*.css && rm -rf img/* && rm -rf font/* && rm -rf js/* && npm run gem-clean",
     "build": "npm run build-css && npm run build-font && npm run build-img && npm run build-js && npm run gem",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",
     "gem-copy-font": "echo ./gem/assets/fonts ./gem/app/assets/fonts | xargs -n 1 cp -R ./font/*",
     "gem-copy-img": "echo ./gem/assets/img ./gem/app/assets/images | xargs -n 1 cp -R ./img/*",
-    "gem-dirs": "mkdir -p ./gem/assets/{css,js,fonts,img} && mkdir -p ./gem/app/assets/{stylesheets,javascript,fonts,images}",
+    "gem-dirs": "mkdir -p ./gem/assets/{css,js,fonts,img} && mkdir -p ./gem/app/assets/{stylesheets,javascript,fonts,images} && mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts",
     "gem-commit": "cd ./gem && git add . && git commit -m 'Updated with latest cg-style assets' && cd ../",
     "gem-push": "cd ./gem && git push origin master && cd ../",
     "lint": "scss-lint -c t .scss-lint.yml",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",
     "gem-copy-font": "echo ./gem/assets/fonts ./gem/app/assets/fonts | xargs -n 1 cp -R ./font/*",
     "gem-copy-img": "echo ./gem/assets/img ./gem/app/assets/images | xargs -n 1 cp -R ./img/*",
-    "gem-dirs": "mkdir -p ./gem/assets/{css,js,fonts,img} && mkdir -p ./gem/app/assets/{stylesheets,javascript,fonts,images} && mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts",
+    "gem-dirs": "mkdir -p ./gem/assets/{css,js,fonts,img} && mkdir -p ./gem/app/assets/{stylesheets,javascript,fonts,images} && mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts ** mkdir -p ./get/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
     "gem-commit": "cd ./gem && git add . && git commit -m 'Updated with latest cg-style assets' && cd ../",
     "gem-push": "cd ./gem && git push origin master && cd ../",
     "lint": "scss-lint -c t .scss-lint.yml",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "copy-font": "mkdir -p ./font && cp node_modules/uswds/dist/fonts/* font/ && cp ./src/font/* ./font",
     "gem": "npm run gem-clone && npm run gem-dirs && npm run gem-copy",
     "gem-clean": "rm -rf ./gem",
-    "gem-clone": "npm run gem-clean && git clone git@github.com:18F/cg-style-gem.git gem",
+    "gem-clone": "npm run gem-clean && git clone https://github.com/18F/cg-style-gem.git",
     "gem-copy": "npm run gem-copy-css && npm run gem-copy-js && npm run gem-copy-font && npm run gem-copy-img",
     "gem-copy-css": "echo ./gem/assets/css ./gem/app/assets/stylesheets | xargs -n 1 cp -R ./css/*",
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",
     "gem-copy-font": "echo ./gem/assets/fonts ./gem/app/assets/fonts | xargs -n 1 cp -R ./font/*",
     "gem-copy-img": "echo ./gem/assets/img ./gem/app/assets/images | xargs -n 1 cp -R ./img/*",
-    "gem-dirs": "mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts mkdir -p ./get/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
+    "gem-dirs": "mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts mkdir -p ./gem/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
     "gem-commit": "cd ./gem && git add . && git commit -m 'Updated with latest cg-style assets' && cd ../",
     "gem-push": "cd ./gem && git push origin master && cd ../",
     "lint": "scss-lint -c t .scss-lint.yml",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",
     "gem-copy-font": "echo ./gem/assets/fonts ./gem/app/assets/fonts | xargs -n 1 cp -R ./font/*",
     "gem-copy-img": "echo ./gem/assets/img ./gem/app/assets/images | xargs -n 1 cp -R ./img/*",
-    "gem-dirs": "mkdir -p ./gem/assets/{css,js,fonts,img} && mkdir -p ./gem/app/assets/{stylesheets,javascript,fonts,images} && mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts ** mkdir -p ./get/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
+    "gem-dirs": "mkdir -p ./gem/assets/fonts && mkdir -p ./gem/app/assets/fonts mkdir -p ./get/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
     "gem-commit": "cd ./gem && git add . && git commit -m 'Updated with latest cg-style assets' && cd ../",
     "gem-push": "cd ./gem && git push origin master && cd ../",
     "lint": "scss-lint -c t .scss-lint.yml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cg-style",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The global style of cloud.gov",
   "main": "js/cg-style.js",
   "scripts": {


### PR DESCRIPTION
This sets up a travis build that does:
- installs npm dependencies
- has to go into and install uwds manually because it hasn't been
  released on npm yet.
- run cg-style build to create all assets and the gem directory
- install gems
- set the cloudgov-style gem to the local gem folder (I do this twice
  because I'm not sure which one works yet)
- build jekyll site
- install percy.io
- snapshot the site with percy for visual regression testing
- deploy to npm when on master branch and it's a tagged commit.
