### PR TITLE
Initial build of components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clean": "rm -rf css/*.css && rm -rf img/* && rm -rf font/* && rm -rf js/* && npm run gem-clean",
     "build": "npm run build-css && npm run build-font && npm run build-img && npm run compile-css && npm run build-js && npm run compile-js && npm run gem",
     "build-css": "mkdir -p ./css && node-sass ./src/css/main.scss ./css/cloudgov-style.css && npm run build-prefix",
+    "build-css-components": "mkdir -p ./css/components && node-sass ./src/css/components -o ./css/components && node-sass ./src/css/base.scss ./css/base.css",
     "build-font": "npm run copy-font",
     "build-js": "mkdir -p ./js && browserify ./src/js/main.js -o ./js/cloudgov-style.js",
     "build-prefix": "postcss --use autoprefixer css/cloudgov-style.css -o ./css/cloudgov-style.css",

--- a/src/css/_core.scss
+++ b/src/css/_core.scss
@@ -1,0 +1,5 @@
+
+@import "../../node_modules/uswds/src/stylesheets/lib/_bourbon.scss";
+@import "../../node_modules/uswds/src/stylesheets/lib/_neat.scss";
+@import "../../node_modules/uswds/src/stylesheets/core/_defaults.scss";
+@import "vars.scss";

--- a/src/css/base/background.scss
+++ b/src/css/base/background.scss
@@ -1,4 +1,7 @@
 
+@import "../override_vars.scss";
+@import "../vars.scss";
+
 body {
   background-color: $color-primary-darkest;
 }

--- a/src/css/base/fonts.scss
+++ b/src/css/base/fonts.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 // Source sans light
 @font-face {
     font-family: 'Source Sans Pro';

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 table {
   border-collapse: collapse;
   border-spacing: 0;

--- a/src/css/base/typography.scss
+++ b/src/css/base/typography.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 body {
   color: $color-base;
   font-weight: 300;

--- a/src/css/components/billboard.scss
+++ b/src/css/components/billboard.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .billboard {
   margin-top: 0;
 

--- a/src/css/components/footer.scss
+++ b/src/css/components/footer.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .footer {
   @include clearfix;
   padding-bottom: 3rem;

--- a/src/css/components/four_up.scss
+++ b/src/css/components/four_up.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .four_up {
   @include clearfix;
 }

--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .header {
   background: $color-white;
   min-height: 6.875rem;

--- a/src/css/components/hex-icon.scss
+++ b/src/css/components/hex-icon.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .hex_icon {
   align-items: center;
   color: $color-white;

--- a/src/css/components/hexagon.scss
+++ b/src/css/components/hexagon.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 $primary-color: $color-primary-alt;
 $alt-color: $color-secondary;
 

--- a/src/css/components/icon.scss
+++ b/src/css/components/icon.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .icon-container {
   height: 3.125rem;
   width: 3.9rem;

--- a/src/css/components/logo.scss
+++ b/src/css/components/logo.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .logo {
   height: 41px;
   width: 234px;

--- a/src/css/components/main-content.scss
+++ b/src/css/components/main-content.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .content {
   background: $color-white;
   padding-left: 2rem;

--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -1,4 +1,7 @@
 
+@import "../core.scss";
+@import "../../../node_modules/uswds/src/stylesheets/core/utilities.scss";
+
 .nav {
   @include unstyled-list;
 

--- a/src/css/components/nav_toggle.scss
+++ b/src/css/components/nav_toggle.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .nav_toggle {
   background: $color-primary-darker;
   cursor: pointer;

--- a/src/css/components/section.scss
+++ b/src/css/components/section.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 $chevron_size: 4.865rem;
 
 .section {

--- a/src/css/components/separator.scss
+++ b/src/css/components/separator.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 $primary-color: $color-primary-alt;
 $alt-color: $color-secondary;
 $center_piece_size: 12px;
@@ -13,7 +15,7 @@ $center_piece_size: 12px;
 
   &:before,
   &:after {
-    background: linear-gradient(to top, $primary-color 0%, 
+    background: linear-gradient(to top, $primary-color 0%,
       lighten($primary-color, 75%) 100%);
     content: '';
     display: block;
@@ -31,7 +33,7 @@ $center_piece_size: 12px;
 .separator-alt {
   &:before,
   &:after {
-    background: linear-gradient(to top, $alt-color 5%, 
+    background: linear-gradient(to top, $alt-color 5%,
       rgba($alt-color, 0.1) 90%);
   }
 }
@@ -42,6 +44,6 @@ $center_piece_size: 12px;
   font-size: $center_piece_size;
   margin-left: 1rem;
   margin-right: 1rem;
-  order: 2; 
+  order: 2;
   width: $center_piece_size;
 }

--- a/src/css/components/sidenav.scss
+++ b/src/css/components/sidenav.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 $width-nav-sidebar: 300px;
 $color-grid-dark:   #727272;
 $color-grid-light:  #e3e4e5;

--- a/src/css/components/three_up.scss
+++ b/src/css/components/three_up.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .three_up {
   @include clearfix;
 }

--- a/src/css/components/title_bar.scss
+++ b/src/css/components/title_bar.scss
@@ -1,4 +1,6 @@
 
+@import "../core.scss";
+
 .title_bar {
   background-color: $color-primary-darkest;
   margin: 0 auto;


### PR DESCRIPTION
Building the individual sass components as CSS components so it's easier
to import them individually into sites with webpack.

This outputs:

```
dist/
- components/
- - billboard.css
- - ...
- base.css
- cloudgov-style.css
```

TODO
- Want to use include paths to limit dipping into node_modules
