### PR TITLE
Add documentation for table

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,9 @@ sass:
 #  style: :compressed
 
 collections:
+  base:
+    output: true
+    permalink: /:path/
   components:
     output: true
     permalink: /:path/

--- a/documentation/_base/table.md
+++ b/documentation/_base/table.md
@@ -1,0 +1,34 @@
+---
+layout: component
+type: component
+title: Table
+---
+
+<table>
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Lorem</td>
+      <td>Ipsum</td>
+      <td>Dolorum</td>
+    </tr>
+    <tr>
+      <td>Lorem</td>
+      <td>Ipsum</td>
+      <td>Dolorum</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+<pre>
+  <code>
+  </code>
+</pre>

--- a/documentation/_includes/header.html
+++ b/documentation/_includes/header.html
@@ -26,14 +26,12 @@
     <!-- start top navigation -->
     <nav class="header-side">
       <ul class="nav">
-        {% for my_page in site.components %}
-          {% if my_page.title %}
-          <li class="nav-link">
-            <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">
-            {{ my_page.title }}</a>
-          {% endif %}
-          </li>
-        {% endfor %}
+        <li class="nav-link">
+          <a class="page-link" href="{{ '/base' | prepend: site.baseurl }}">Base Styles</a>
+        </li>
+        <li class="nav-link">
+          <a class="page-link" href="{{ '/components' | prepend: site.baseurl }}">Component Styles</a>
+        </li>
       </ul>
     </nav>
     <!-- end top navigation -->

--- a/documentation/_layouts/collection.html
+++ b/documentation/_layouts/collection.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+  <body>
+
+    {% include header.html %}
+
+    <main class="sidenav-parent">
+      <aside class="sidenav">
+        <ul class="usa-sidenav-list sidenav-list sidenav-level-one">
+          {% for item in site[page.collection] %}
+            {% if item.title %}
+              <li>
+                <a href="{{ item.url | prepend: site.baseurl }}">
+                  {{ item.title }}
+                </a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </aside>
+      <div class="sidenav-main">
+        <div class="usa-content content">
+          <h1>{{ page.title }}</h1>
+          {{ content }}
+        </div>
+      </div>
+    </main>
+
+    {% include footer.html %}
+
+  </body>
+
+</html>

--- a/documentation/base_styles.md
+++ b/documentation/base_styles.md
@@ -1,0 +1,8 @@
+---
+collection: base
+layout: collection
+permalink: base
+title: Base Styles
+---
+
+These are the base styles

--- a/documentation/component_styles.md
+++ b/documentation/component_styles.md
@@ -1,0 +1,8 @@
+---
+collection: components
+layout: collection
+permalink: components
+title: Component Styles
+---
+
+These are the component styles


### PR DESCRIPTION
In reviewing #51 I noticed that there isn't documentation for the base styles, though it would definitely be useful for cases like this. I've gone ahead and done a super basic breakup just to show the direction I was thinking and get feedback. If we like this, I can finish it up before this PR is merged.

This PR so far:
- Add documentation for table base style and creates a "base" collection
- Changes the navbar to only have base and component links. Each goes to a collection index page that has a sidenav element with all of the collection items.

Screenshot: ![](https://s3.amazonaws.com/f.cl.ly/items/2G3i3l000n2f0n1E380d/Screen%20Shot%202016-04-20%20at%209.46.03%20PM.png?v=7fd9d230)

Before this is merged we should:
- [x] Agree that we want to go in this direction for documentation
- [ ] Fix nav bar stylings so that two elements aren't so far apart
- [ ] Add sidenav to each item within a collection for easier navigation
- [ ] Have the index page of each collection show all the elements in one long list

@msecret what do you think?
