### PR TITLE
Do not create directories named "-p" and "mkdir"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gem-copy-js": "echo ./gem/assets/js ./gem/app/assets/javascript | xargs -n 1 cp -R ./js/*",
     "gem-copy-font": "echo ./gem/assets/font ./gem/app/assets/font | xargs -n 1 cp -R ./font/*",
     "gem-copy-img": "echo ./gem/assets/img ./gem/app/assets/images | xargs -n 1 cp -R ./img/*",
-    "gem-dirs": "mkdir -p ./gem/assets/font && mkdir -p ./gem/app/assets/font mkdir -p ./gem/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
+    "gem-dirs": "mkdir -p ./gem/assets/font && mkdir -p ./gem/app/assets/font && mkdir -p ./gem/assets/img && mkdir -p ./gem/app/assets/images && mkdir -p ./gem/assets/js && mkdir -p ./gem/app/assets/javascript && mkdir -p ./gem/assets/css && mkdir -p ./gem/app/assets/stylesheets",
     "gem-commit": "cd ./gem && git add . && git commit -m 'Updated with latest cloudgov-style assets' && cd ../",
     "gem-push": "cd ./gem && git push origin master && cd ../",
     "lint": "scss-lint -c t .scss-lint.yml",


### PR DESCRIPTION
We were missing a "&&", which resulted in a few extra directories being created. This fixes the command so no extraneous folders are created.
