### PR TITLE
Add font awesome as a depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The global style of cloud.gov",
   "main": "src/js/main.js",
   "scripts": {
-    "clean": "rm -rf css/*.css && rm -rf img/* && rm -rf font/* && rm -rf js/* && npm run gem-clean",
+    "clean": "rm -rf css && rm -rf img && rm -rf font && rm -rf js && npm run gem-clean",
     "build": "npm run build-css && npm run build-css-components && npm run build-font && npm run build-img && npm run compile-css && npm run build-js && npm run compile-js && npm run gem",
     "build-css": "mkdir -p ./css && node-sass ./src/css/main.scss ./css/cloudgov-style.css && npm run build-prefix",
     "build-css-components": "mkdir -p ./css/components && node-sass ./src/css/components -o ./css/components && node-sass ./src/css/base.scss ./css/base.css",
@@ -15,7 +15,12 @@
     "compile-css": "cleancss ./css/cloudgov-style.css -o ./css/cloudgov-style-min.css",
     "compile-js": "uglifyjs ./js/cloudgov-style.js -o ./js/cloudgov-style-min.js",
     "copy-img": "cp -r node_modules/uswds/dist/img/*  img/ && cp ./src/img/* ./img",
-    "copy-font": "mkdir -p ./font && cp node_modules/uswds/dist/fonts/* font/ && cp ./src/font/* ./font",
+    "copy-font": "mkdir -p ./font &&  npm run copy-uswds-font && npm run copy-fontawesome",
+    "copy-src-font": "cp ./src/font/* ./font",
+    "copy-uswds-font": "cp node_modules/uswds/dist/fonts/* font/ && cp ./src/font/* ./font",
+    "copy-fontawesome": "npm run copy-fontawesome-css && npm run copy-fontawesome-font",
+    "copy-fontawesome-css": "cat node_modules/font-awesome/css/font-awesome.min.css | sed 's;/fonts/;/font/;g' > ./css/font-awesome.min.css",
+    "copy-fontawesome-font": "cp node_modules/font-awesome/fonts/font* font/ && cp ./src/font/* ./font",
     "gem": "npm run gem-clone && npm run gem-dirs && npm run gem-copy",
     "gem-clean": "rm -rf ./gem",
     "gem-clone": "npm run gem-clean && git clone https://github.com/18F/cg-style-gem.git ./gem",
@@ -43,6 +48,7 @@
   },
   "homepage": "https://github.com/18F/cg-style#readme",
   "dependencies": {
+    "font-awesome": "^4.6.1",
     "uswds": "git+https://git@github.com/18F/web-design-standards.git#1007-var_for_asset_paths"
   },
   "devDependencies": {


### PR DESCRIPTION
In the process of documenting how the sidenav element works I noticed we didn’t have font-awesome included which resulted in the glyphs not being displayed properly. Added the library as a dependency and included some build scripts that are run automatically on `npm run build`

The `copy-fontawesome-css` script is weird looking because I alter the paths required in the CSS file to match our current file structure. We currently use `/font` so that is where the browser should look for font awesome fonts.

I raised some related concerns in 18F/cg-style-gem#5, which could change some parts of this implementation
