### PR TITLE
Document a more complex sidenav example

### DIFF
--- a/documentation/_components/sidenav.md
+++ b/documentation/_components/sidenav.md
@@ -4,39 +4,79 @@ type: component
 title: Sidenav
 ---
 
-<aside id="sidebar" class="sidenav">
-  <ul class="usa-sidenav-list sidenav-list sidenav-level-one">
-    <li class="sub-menu">
-      <a href="javascript:;" class="">
-        <span>Introduction</span>
-        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
-      </a>
-    </li>     
-    <li class="sub-menu">
-      <a href="javascript:;" class="">
-        <span>Documentation</span>
-        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
-      </a>
-    </li>
-    <li class="sub-menu">
-      <a href="javascript:;" class="">
-        <span>Another link</span>
-        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
-      </a>
-    </li>
-  </ul>
-</aside>
+<div id="sidebar" class="sidenav-parent">
+  <aside class="sidenav">
+    <ul class="usa-sidenav-list sidenav-list sidenav-level-one">
+      <li class="sub-menu">
+        <a href="javascript:;" class="">
+          <span>Item 1</span>
+          <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        </a>
+        <ul class="usa-sidenav-sub_list sidenav-list sidenav-level-two nested-menu " style="display: none; ">
+          <li class="sub-menu">
+            <a href="javascript:;" class="">
+              <span>Overview</span>
+              <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+            </a>
+            <ul class="sidenav-list sidenav-level-three" style="display: none; ">
+              <li><a href="/intro/overview/what-is-cloudgov/">What Is cloud.gov?</a></li>
+              <li><a href="/intro/overview/why-use-cloudgov/">Why Agencies Should Use It</a> </li>
+              <li><a href="/intro/overview/using-cloudgov-paas/">How to Use It</a> </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="sub-menu">
+        <a href="javascript:;" class="">
+          <span>Item 2</span>
+          <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        </a>
+      </li>
+      <li class="sub-menu">
+        <a href="javascript:;" class="">
+          <span>Item 3</span>
+          <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        </a>
+      </li>
+    </ul>
+  </aside>
+</div>
 
 <pre>
   <code>
-    &lt;aside id="sidebar" class="sidenav">
+    &lt;aside class="sidenav">
       &lt;ul class="usa-sidenav-list sidenav-list sidenav-level-one">
         &lt;li class="sub-menu">
           &lt;a href="javascript:;" class="">
-            &lt;span>Introduction</span>
-            &lt;span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+            &lt;span>Item 1&lt;/span>
+            &lt;span class="menu-arrow sidenav-arrow fa fa-angle-right">&lt;/span>
           &lt;/a>
-        &lt;/li>    
+          &lt;ul class="usa-sidenav-sub_list sidenav-list sidenav-level-two nested-menu " style="display: none; ">
+            &lt;li class="sub-menu">
+              &lt;a href="javascript:;" class="">
+                &lt;span>Overview&lt;/span>
+                &lt;span class="menu-arrow sidenav-arrow fa fa-angle-right">&lt;/span>
+              &lt;/a>
+              &lt;ul class="sidenav-list sidenav-level-three" style="display: none; ">
+                &lt;li>&lt;a href="/intro/overview/what-is-cloudgov/">What Is cloud.gov?&lt;/a>&lt;/li>
+                &lt;li>&lt;a href="/intro/overview/why-use-cloudgov/">Why Agencies Should Use It&lt;/a> &lt;/li>
+                &lt;li>&lt;a href="/intro/overview/using-cloudgov-paas/">How to Use It&lt;/a> &lt;/li>
+              &lt;/ul>
+            &lt;/li>
+          &lt;/ul>
+        &lt;/li>
+        &lt;li class="sub-menu">
+          &lt;a href="javascript:;" class="">
+            &lt;span>Item 2&lt;/span>
+            &lt;span class="menu-arrow sidenav-arrow fa fa-angle-right">&lt;/span>
+          &lt;/a>
+        &lt;/li>
+        &lt;li class="sub-menu">
+          &lt;a href="javascript:;" class="">
+            &lt;span>Item 3&lt;/span>
+            &lt;span class="menu-arrow sidenav-arrow fa fa-angle-right">&lt;/span>
+          &lt;/a>
+        &lt;/li>
       &lt;/ul>
     &lt;/aside>
   </code>

--- a/documentation/_includes/head.html
+++ b/documentation/_includes/head.html
@@ -6,6 +6,8 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
+  <link rel="stylesheet" href="{{ "/assets/css/font-awesome.min.css" | prepend: site.baseurl }}">
+
   <link rel="stylesheet" href="{{ "/assets/css/cloudgov-style.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/documentation/_includes/scripts.html
+++ b/documentation/_includes/scripts.html
@@ -1,0 +1,2 @@
+<script src="https://docs.cloud.gov/js/main.js"></script>
+<!-- <script src="{{ '/assets/js/main.js' | prepend: site.baseurl }}"></script> -->

--- a/documentation/_layouts/collection.html
+++ b/documentation/_layouts/collection.html
@@ -30,7 +30,7 @@
     </main>
 
     {% include footer.html %}
-
+    {% include scripts.html %}
   </body>
 
 </html>

--- a/documentation/_layouts/default.html
+++ b/documentation/_layouts/default.html
@@ -14,7 +14,7 @@
     </main>
 
     {% include footer.html %}
-
+    {% include scripts.html %}
   </body>
 
 </html>


### PR DESCRIPTION
The documentation now includes nested menus for easier reference of how the sidenav element is styled. To accomplish this I needed:
- To add example code. I used a modified version of the sidenav on [docs.cloud.gov](https://docs.cloud.gov)
- To add `font-awesome` as a dependency and build it into the site
- To add `main.js` from the production docs site to give the sidenav the proper behavior.

This should be merged after #60 
