### PR TITLE
Add sidenav-arrow class for glyphs

### DIFF
--- a/documentation/_components/sidenav.md
+++ b/documentation/_components/sidenav.md
@@ -9,19 +9,19 @@ title: Sidenav
     <li class="sub-menu">
       <a href="javascript:;" class="">
         <span>Introduction</span>
-        <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
       </a>
     </li>     
     <li class="sub-menu">
       <a href="javascript:;" class="">
         <span>Documentation</span>
-        <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
       </a>
     </li>
     <li class="sub-menu">
       <a href="javascript:;" class="">
         <span>Another link</span>
-        <span class="menu-arrow sidenav-arrow fa fa-angle-right"></span>
+        <span class="menu-arrow sidenav-arrow sidenav-arrow-right"></span>
       </a>
     </li>
   </ul>

--- a/src/css/components/sidenav.scss
+++ b/src/css/components/sidenav.scss
@@ -85,7 +85,20 @@ $color-level-3-bg:  #595959;
 }
 
 .sidenav-arrow {
+  border: 1px solid white;
+  border-left-color: transparent;
+  border-top-color: transparent;
   float: right;
+  height: .6em;
+  width: .6em;
+}
+
+.sidenav-arrow-right {
+  transform: rotate(-45deg);
+}
+
+.sidenav-arrow-down {
+  transform: rotate(45deg);
 }
 
 .sidenav-active {


### PR DESCRIPTION
Instead of using font-awesome for a bunch of glyphs and making cg-style a more complex dependency, I just made the sidenav arrows using pure CSS.

Added new classes to documentation page for sidenav.

This is an alternative approach to #57
