### PR TITLE
Import override vars into title bar component

### DIFF
--- a/src/css/components/title_bar.scss
+++ b/src/css/components/title_bar.scss
@@ -1,4 +1,5 @@
 
+@import "../override_vars.scss";
 @import "../core.scss";
 
 .title_bar {


### PR DESCRIPTION
The `color-primary-darkest` value wasn't being set properly on the title bar because `override_vars` wasn't being imported into the component.
