### PR TITLE
Use lighter font for <legend> text

### DIFF
--- a/src/css/base/form.scss
+++ b/src/css/base/form.scss
@@ -5,6 +5,7 @@ form {
 
 legend {
   font-size: 1.2rem;
+  font-weight: 300;
   margin-bottom: .5rem;
 }
 
@@ -17,7 +18,7 @@ input[type="email"] {
   padding: 0.7rem 0.7rem;
 }
 
-form button[type="submit"], 
+form button[type="submit"],
 form input[type="submit"] {
   margin-top: 1.5rem;
 }


### PR DESCRIPTION
I used a much lighter font weight for the legend text because we want to use the legend element for 508 compliance (18f/cg-landing#65) on the cg-landing site, and this matches the existing style.

I think this requires to the go-ahead from @vz3 and/or @thisisdano 
