### PR TITLE
Import override_vars into nav.scss

### DIFF
--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -1,4 +1,5 @@
 
+@import "../override_vars.scss";
 @import "../core.scss";
 @import "../../../node_modules/uswds/src/stylesheets/core/utilities.scss";
 


### PR DESCRIPTION
`override_vars.scss` was not being imported into `nav.scss`, and therefore the `.nav-link a` elements didn't have a color that matched with cloudgov-style.

Imported `override_vars.scss` into `nav.scss` so that `$color-gray` would be set correctly.
