### PR TITLE
Include trailing "/"s for base & component pages

### DIFF
--- a/documentation/base_styles.md
+++ b/documentation/base_styles.md
@@ -1,7 +1,7 @@
 ---
 collection: base
 layout: collection
-permalink: base
+permalink: base/
 title: Base Styles
 ---
 

--- a/documentation/component_styles.md
+++ b/documentation/component_styles.md
@@ -1,7 +1,7 @@
 ---
 collection: components
 layout: collection
-permalink: components
+permalink: components/
 title: Component Styles
 ---
 


### PR DESCRIPTION
Currently the header links are missing the trailing slashes and therefore the link to `/base` isn't working as the file is actually at `/base.html`. I changed the permalinks so that the file extension and trailing slash are not needed when visiting the documentation in a browser.
