### PR TITLE
Triage styles / Tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /css/
 /gem/
 /_site/
+
+.DS_Store

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -4,13 +4,22 @@
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  
+  button,
+  [type="button"] {
+    padding: .5rem;
+  }
 
   th, 
   td {
-    padding: .25em;
+    padding: .25em 1.25em;
     padding-left: 0px;
     border: none;
     border-top: 1px solid;
+  }
+  
+  td:last-child {
+    padding-right: 0;
   }
   
   thead tr {
@@ -61,9 +70,6 @@ table {
       justify-content: center;
       margin: 0;
       width: 0;
-      &:last-child {
-        border-style: solid;
-      }
 
       span {
         margin-top: 3rem;
@@ -104,5 +110,26 @@ table {
 
 td table {
   margin: 0;
+}
+
+// td .tableWrapper
+// this rule is outputting as `.base__tableWrapper___kwCST` in the final compiled sheet
+// why??
+// rewritten as:
+td div {
+  margin: 8px 0;
+  border: 1px solid $color-primary;
+  padding: 16px;
+  border-radius: 3px;
+  margin-bottom: 3rem;
+}
+
+td thead th {
+  color: $color-primary;
+  border-bottom: 1px solid $color-primary;
+}
+
+td [label="Actions"] {
+  text-align: right;
 }
 

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -112,11 +112,7 @@ td table {
   margin: 0;
 }
 
-// td .tableWrapper
-// this rule is outputting as `.base__tableWrapper___kwCST` in the final compiled sheet
-// why??
-// rewritten as:
-td div {
+td .tableWrapper {
   margin: 8px 0;
   border: 1px solid $color-primary;
   padding: 16px;

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -12,7 +12,7 @@ table {
 
   th, 
   td {
-    padding: .25em 1.25em;
+    padding: .5em 1.25em;
     padding-left: 0px;
     border: none;
     border-top: 1px solid;
@@ -29,6 +29,8 @@ table {
   thead th {
     border-top: none;
     border-bottom: 3px solid;
+    font-size: .8rem;
+    font-weight: 800;
   }
 
   tbody {

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -5,6 +5,23 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 
+  th, 
+  td {
+    padding: .25em;
+    padding-left: 0px;
+    border: none;
+    border-top: 1px solid;
+  }
+  
+  thead tr {
+    background-color: transparent;
+  }
+  
+  thead th {
+    border-top: none;
+    border-bottom: 3px solid;
+  }
+
   tbody {
     display: flex;
 
@@ -44,9 +61,7 @@ table {
       justify-content: center;
       margin: 0;
       width: 0;
-
       &:last-child {
-        border-bottom-width: 1px;
         border-style: solid;
       }
 
@@ -65,7 +80,6 @@ table {
       }
 
       @include media($medium-screen) {
-        border-width: 1px;
         display: table-cell;
         height: inherit;
         width: auto;
@@ -80,13 +94,7 @@ table {
       height: 21rem;
       justify-content: center;
 
-      &:last-child {
-        border-bottom-width: 1px;
-        border-style: solid;
-      }
-
       @include media($medium-screen) {
-        border-width: 1px;
         display: table-cell;
         height: inherit;
       }

--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -115,9 +115,9 @@ td table {
 }
 
 td .tableWrapper {
-  margin: 8px 0;
+  margin: .8rem 0;
   border: 1px solid $color-primary;
-  padding: 16px;
+  padding: 1.6rem;
   border-radius: 3px;
   margin-bottom: 3rem;
 }

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -78,4 +78,6 @@ button,
 [type="reset"],
 [type="image"] {
   font-size: inherit;
+  padding: 1rem;
+  border-radius: 2px;
 }


### PR DESCRIPTION
This change addresses the usability of tables, but does not address whether a table is the correct solution for a particular display, nor does it explicitly address the kind of data displayed or its arrangement in the template. In general, this is a triage solution that tries to improve usability but does not claim to be the best display solution.

**Goals**
- To reduce atomization of individual tabular data
  - removing the border from each individual cell, replacing it with border simply on the top and bottom (encouraging a row read)
  - reducing the padding of each cell, keeping all the columnar data closer together (encouraging a column read).
- To improve hierarchy of nested data (tricky because there's no "canonical" role that a nested table plays)
  - increase distinction between nested table and containing table
  - increase connection between nested table and related containing data
- Improve button fit on tabular data
  - reduced button height in tables to fit better into rows and pack tighter

**Known Issues**
- Changes are all in stylesheets, targeting nested tables with `td table`; the best solution would use classes to name nested tables explicitly and avoid nested selectors. Not all nested tables need necessarily use the "card" style; it could be assigned explicitly with a class.
- Similarly, the compressed button style used in the tables could be assigned with a class, rather than using a contextual style, `table button`
- targeting `td .tableWrapper` resulted in a strange compilation quirk (commented in the stylesheet) — idiosyncratically compiling to `.base__tableWrapper___kwCST` in the final compiled styles. I changed the selector to `td div` to get it working, but this is too broad.
- Using stylemaps on development builds could speed up development by helping any dev easily find and edit rules spread over multiple stylesheets.
- I aligned action buttons right with a hacky solution, targeting `td [label="Actions"]`. Perhaps there's a more explicit class we can use to align both the actions button and the actions column hed text right. (Right now the button is aligned right, but the hed is aligned left)
  - It would also be better if the buttons in the action column had no right margin, so they'd align exactly to the right edge of the table
- The styling DOES NOT play well with mobile. This is a triage, non-mobile solution only.

**Improvements**
- I'd prefer to have a heavy line over rows that "begin" new data sections (i.e. those that contain a new row of data in the primary table and contain a nested table themselves, like subsequent rows of primary service info), but this is impossible to accurately target only with styles
- Some columns in the service instance table are redundant ("Free") or confusing ("Description")
- Individual column widths should be explicitly set in repeating tables (or nested tables) to improve table-table comparison and scanning. As is, the column width changes from table to table, depending on each table's specific data. Maybe use width-classes to set percentage-width columns.
- timecode should be formatted to something human-readable (and is arguably not necessary in service description data)
- The service instance name could be classed in such a way to make it more prominent (like, bold)

**Old:**
<img width="392" alt="screen shot 2016-06-07 at 7 46 49 am" src="https://cloud.githubusercontent.com/assets/11464021/15862397/63718d8c-2c84-11e6-9e33-1cce82fa6997.png">

**New:**
<img width="385" alt="screen shot 2016-06-07 at 7 32 06 am" src="https://cloud.githubusercontent.com/assets/11464021/15862405/6dfc528c-2c84-11e6-9138-d1787d622a1e.png">
