### PR TITLE
Improve UI pattern for tab nav

### DIFF
--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -44,15 +44,16 @@
 $color-lightgray: #bababa;
 $border-highlight: 3px;
 $padding-highlight: 4px;
+$size-xsmall: .8rem;
 
 .nav-tabs {
   display: flex;
   flex-direction: row;
-  font-size: .8rem;
+  margin-top: 1rem;
+  font-size: $size-xsmall;
   text-transform: uppercase;
   letter-spacing: .1em;
   color: $color-lightgray;
-  margin-top: 1rem;
 }
 
 .nav-tabs li {
@@ -66,19 +67,19 @@ $padding-highlight: 4px;
 .nav-tabs a {
   display: block;
   width: auto;
-  text-align: center;
-  color: $color-lightgray;
-  font-weight: 600;
+  padding-bottom: ($padding-highlight + $border-highlight - 1);
   border-bottom: 1px solid $color-lightgray;
-  padding-bottom: $padding-highlight + $border-highlight - 1;
+  text-align: center;
+  font-weight: 600;
+  color: $color-lightgray;
 }
 
 .nav-tabs .active a,
 .nav-tabs a:hover {
-    color: $color-primary;
-    text-decoration: none;
     padding-bottom: $padding-highlight;
     border-bottom: $border-highlight solid $color-primary; 
+    text-decoration: none;
+    color: $color-primary;
 } 
 
 // secondary tabs

--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -38,3 +38,55 @@
     padding-top: 0;
   }
 }
+
+// triage tab treatment
+
+$color-lightgray: #bababa;
+$border-highlight: 3px;
+$padding-highlight: 4px;
+
+.nav-tabs {
+  display: flex;
+  flex-direction: row;
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: $color-lightgray;
+  margin-top: 1rem;
+}
+
+.nav-tabs li {
+  flex: 1;
+  &:before {
+    display: none;
+  }
+}
+
+// gettin deep
+.nav-tabs a {
+  display: block;
+  width: auto;
+  text-align: center;
+  color: $color-lightgray;
+  font-weight: 600;
+  border-bottom: 1px solid $color-lightgray;
+  padding-bottom: $padding-highlight + $border-highlight - 1;
+}
+
+.nav-tabs .active a,
+.nav-tabs a:hover {
+    color: $color-primary;
+    text-decoration: none;
+    padding-bottom: $padding-highlight;
+    border-bottom: $border-highlight solid $color-primary; 
+} 
+
+// secondary tabs
+
+.nav-tabs + div .nav-tabs {
+  .active a,
+  a:hover {
+    border-color: $color-secondary;
+    color: $color-secondary;
+  }
+}


### PR DESCRIPTION
Some dashboard data is organized with tabbed navigation. The current dashboard displayed this tabbed navigation as a simple `ul`, but it needed to be clear that this list was a nav and that it functioned in the conventional tab style.

**Goals**
- Give the nav a more conventional tabbed look
- Make it clear what tab was active and which can be selected
- Differentiate nested tab navs from the parent nav

**Known issues**
- Doesn't respond well to mobile

---

**Before**
<img width="714" alt="screen shot 2016-06-07 at 5 00 34 pm" src="https://cloud.githubusercontent.com/assets/11464021/15878638/7caeeafe-2cd1-11e6-94ee-91ee792d35e4.png">

---

**After**
<img width="718" alt="screen shot 2016-06-07 at 4 43 05 pm" src="https://cloud.githubusercontent.com/assets/11464021/15878646/84420936-2cd1-11e6-81e1-1fc4aef57f25.png">
