### PR TITLE
Adjust colors in disclaimer for 508 compliance

### DIFF
--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -12,7 +12,15 @@
 .usa-disclaimer {
   // Requires being overridden because uswds sets a different root font-size on
   // <html> which effects all rem units.
+  color: $color-disclaimer-text;
   font-size: 0.9rem;
+
+  a,
+  a:active,
+  a:hover,
+  a:visited {
+    color: $color-disclaimer-link;
+  }
 }
 
 .usa-button {

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -26,6 +26,9 @@ $color-visited:              #4c2c92;
 $color-gray:                 #595959;
 $color-gray-dark:            darken($color-gray, 20%);
 
+$color-disclaimer-text:      #000000;
+$color-disclaimer-link:      #0071BC;
+
 $color-base: $color-gray;
 $text-max-width:    660px;
 $site-max-width:    1040px;


### PR DESCRIPTION
Fixes #68 by adjusting the colors in the `.usa-disclaimer` component.
