### PR TITLE
New tab nav colors for 508

### DIFF
--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -66,21 +66,21 @@ $size-xsmall: .8rem;
 
 // gettin deep
 .nav-tabs a {
-  display: block;
-  width: auto;
-  padding-bottom: ($padding-highlight + $border-highlight - 1);
   border-bottom: 1px solid $color-lightgray;
-  text-align: center;
+  color: $color-gray;
+  display: block;
   font-weight: 600;
-  color: $color-lightgray;
+  padding-bottom: ($padding-highlight + $border-highlight - 1);
+  text-align: center;
+  width: auto;
 }
 
 .nav-tabs .active a,
 .nav-tabs a:hover {
-  padding-bottom: $padding-highlight;
   border-bottom: $border-highlight solid $color-primary;
-  text-decoration: none;
   color: $color-primary;
+  padding-bottom: $padding-highlight;
+  text-decoration: none;
 }
 
 // secondary tabs


### PR DESCRIPTION
This adjusts the inactive tab nav state color to `$color-gray` — effectively `#595959` — to increase the contrast level to `7:1`

---

<img width="854" alt="screen shot 2016-06-17 at 9 57 37 am" src="https://cloud.githubusercontent.com/assets/11464021/16158503/4fdf1fb4-3472-11e6-9418-780066407c0b.png">
