### PR TITLE
Update code blocks to be scrollable

### DIFF
--- a/src/css/base/formatted.scss
+++ b/src/css/base/formatted.scss
@@ -1,5 +1,5 @@
 
 pre {
-  white-space: pre-wrap;
   word-wrap: break-word;
+  overflow: auto;
 }


### PR DESCRIPTION
Because of the work on 18F/cg-docs#291, we need scrollable `<code>` blocks.
