### PR TITLE
Show code blocks in documentation

### DIFF
--- a/documentation/css/main.scss
+++ b/documentation/css/main.scss
@@ -19,7 +19,7 @@ pre {
 }
 
 .header-title {
-  span { 
+  span {
     display: inline-block;
     margin-left: 10px;
     margin-top: 6px;
@@ -36,16 +36,12 @@ pre {
 
   // Attempt a very clean test environment for visual regression testing
   &.testable {
-    pre {
-      display: none;
-    }
-
     .example {
       margin-top: 0;
     }
 
     .force-inline {
-      display: initial; 
+      display: initial;
       margin-bottom: 0;
       margin-right: 0;
       text-align: initial;
@@ -92,4 +88,3 @@ pre {
   background-color: #1F2C38;
   margin-top: 6rem
 }
-


### PR DESCRIPTION
We weren’t showing the pre-formatted code blocks in the documentation because of the visual regression testing, but now that:
1. We are not currently using any automated visual regression tester
2. The documentation is in a more stable place so it won’t “break” on code examples as often

I’ve gone ahead and removed the `display: none;` so that users of the documentation site will be able to easily see code structure and not have to use the developer tools.
