### PR TITLE
Add visual regression test for nested lists.

### DIFF
--- a/documentation/_base/lists.md
+++ b/documentation/_base/lists.md
@@ -1,0 +1,36 @@
+---
+layout: component
+type: component
+title: Lists
+---
+
+<!-- 
+
+ This is really just a manual test to ensure that we're using a version
+ of uswds that has the following issue fixed:
+
+ https://github.com/18F/web-design-standards/issues/1328
+
+-->
+
+<ol>
+  <li>
+    i am the first item in an ordered list.
+    <ul>
+      <li>I'm the first item in a nested <em>unordered</em> list.</li>
+    </ul>
+  </li>
+</ol>
+
+<pre>
+  <code>
+&lt;ol>
+  &lt;li>
+    i am the first item in an ordered list.
+    &lt;ul>
+      &lt;li>I'm the first item in a nested &lt;em>unordered&lt;/em> list.&lt;/li>
+    &lt;/ul>
+  &lt;/li>
+&lt;/ol>
+  </code>
+</pre>


### PR DESCRIPTION
This adds a visual regression test for lists at `/lists/` which helps us ensure that we've picked up https://github.com/18F/web-design-standards/pull/1329.

For that matter, we _haven't_ yet picked up that fix, so the page currently looks like this:

![screen shot 2016-08-03 at 6 11 10 pm](https://cloud.githubusercontent.com/assets/124687/17383759/b5535786-59a5-11e6-9399-3fb164db77f6.png)

In order to actually upgrade to a version of uswds with the fix, I need https://github.com/18F/web-design-standards/pull/1376 merged first, though.
