### PR TITLE
Fix extra border on panel

### DIFF
--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -33,6 +33,12 @@ h4 + .panel {
   margin-top: 1rem;
 }
 
+.panel-group:last-child {
+  .panel-row {
+    border-bottom: 0;
+  }
+}
+
 .panel-actions {
   > * {
     margin-right: 2rem;


### PR DESCRIPTION
When the last panel row in the last panel group has the bottom border
it doubles up with panel-rows border.
