### PR TITLE
Upgrading cg-style to use v0.12.1 of the Draft USWDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "homepage": "https://github.com/18F/cg-style#readme",
   "dependencies": {
-    "uswds": "~0.10.0"
+    "uswds": "~0.12.1"
   },
   "devDependencies": {
     "@18f/stylelint-rules": "^2.0.0",

--- a/src/css/base/lists.scss
+++ b/src/css/base/lists.scss
@@ -1,6 +1,0 @@
-
-ul,
-ol {
-  margin: 1rem 0 1rem 0.9em;
-  padding-left: 0;
-}

--- a/src/css/components/sidenav.scss
+++ b/src/css/components/sidenav.scss
@@ -84,6 +84,7 @@ $color-heading:     $color-primary-alt-light;
   li {
     border-top: 0;
     font-size: 0.9rem;
+    list-style: none;
   }
 
 }
@@ -196,6 +197,7 @@ $color-heading:     $color-primary-alt-light;
   margin-bottom: 0;
   margin-left: 0;
   margin-top: 0;
+  padding-left: 0;
 
   > li {
     background-color: $color-level-3-bg;


### PR DESCRIPTION
This pull request updates cg-style to use [v0.12.1](https://github.com/18F/web-design-standards/releases/tag/v0.12.1) of the uswds. It is a major release of the Standards and includes the new headers component.

Fixes #144
