### PR TITLE
Margins for different amount of panel actions

### DIFF
--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -46,6 +46,15 @@ h4 + .panel {
       margin-right: 0;
     }
   }
+
+  .action {
+    margin-left: 0;
+    margin-right: 0;
+
+    & + .action {
+      margin-left: 0.5rem;
+    }
+  }
 }
 
 .panel-header {


### PR DESCRIPTION
Configures margins correctly for when there are different amounts
of panel actions. So layout will be correct with one action vs
multiple. Used the adjacent sibling selector to only apply margin
when two actions next to eachother.
