### PR TITLE
Added .fa styles back for proper display in docs

### DIFF
--- a/src/css/base/typography.scss
+++ b/src/css/base/typography.scss
@@ -179,3 +179,9 @@ hr {
   border-top: 1px solid $color-lightgray;
   padding: $grid-05 0;
 }
+
+.fa {
+  font-size: 80%;
+  padding-right: $grid-05;
+  width: 1.5em;
+}


### PR DESCRIPTION
We stripped my `.fa` styles out of the `master` version, but they need to be there for proper display of the icons in the docs nav.