### PR TITLE
Prototype breadcrumb nav

### DIFF
--- a/src/css/components/all.scss
+++ b/src/css/components/all.scss
@@ -16,6 +16,7 @@
 @import 'icon.scss';
 @import 'main-content.scss';
 @import 'nav.scss';
+@import 'nav-breadcrumb.scss';
 @import 'nav_toggle.scss';
 @import 'panel.scss';
 @import 'quote.scss';

--- a/src/css/components/nav-breadcrumb.scss
+++ b/src/css/components/nav-breadcrumb.scss
@@ -1,3 +1,10 @@
+@import '../core.scss';
+
+.nav-breadcrumb {
+  background-color: $color-white;
+  padding: 1rem 2rem;
+}
+
 .nav-breadcrumb-select-wrapper {
   display: inline-block;
 }

--- a/src/css/components/nav-breadcrumb.scss
+++ b/src/css/components/nav-breadcrumb.scss
@@ -1,15 +1,15 @@
 @import '../core.scss';
 
-.nav-breadcrumb {
+.nav_breadcrumb {
   background-color: $color-white;
   padding: 1rem 2rem;
 }
 
-.nav-breadcrumb-select-wrapper {
+.nav_breadcrumb-select_wrapper {
   display: inline-block;
 }
 
-.nav-breadcrumb-divider {
+.nav_breadcrumb-divider {
   font-size: 1.5rem;
   font-weight: 100;
   line-height: 1;
@@ -17,7 +17,7 @@
   vertical-align: middle;
 }
 
-.nav-breadcrumb-select {
+.nav_breadcrumb-select {
   position: relative;
   width: 16rem;
 
@@ -35,7 +35,6 @@
     height: 1rem;
     top: 0.6rem;
   }
-
 }
 
 .nav-breadcrumb-select-org {
@@ -44,13 +43,13 @@
   }
 }
 
-.nav-breadcrumb-select-space {
+.nav_breadcrumb-select-space {
   &::before {
     background-image: url('#{$static-img-path}/space-small.svg');
   }
 }
 
-.nav-breadcrumb-select-app {
+.nav_breadcrumb-select-app {
   &::before {
     background-image: url('#{$static-img-path}/app-small.svg');
   }

--- a/src/css/components/nav-breadcrumb.scss
+++ b/src/css/components/nav-breadcrumb.scss
@@ -1,0 +1,50 @@
+.nav-breadcrumb-select-wrapper {
+  display: inline-block;
+}
+
+.nav-breadcrumb-divider {
+  font-size: 1.5rem;
+  font-weight: 100;
+  line-height: 1;
+  margin: 0 0.5rem;
+  vertical-align: middle;
+}
+
+.nav-breadcrumb-select {
+  position: relative;
+  width: 16rem;
+
+  select {
+    padding-left: 2rem;
+  }
+
+  &::before {
+    background-image: url('#{$static-img-path}/org-small.svg');
+    background-repeat: no-repeat;
+    content: '';
+    position: absolute;
+    left: 0.8rem;
+    width: 1rem;
+    height: 1rem;
+    top: 0.6rem;
+  }
+
+}
+
+.nav-breadcrumb-select-org {
+  &::before {
+    background-image: url('#{$static-img-path}/org-small.svg');
+  }
+}
+
+.nav-breadcrumb-select-space {
+  &::before {
+    background-image: url('#{$static-img-path}/space-small.svg');
+  }
+}
+
+.nav-breadcrumb-select-app {
+  &::before {
+    background-image: url('#{$static-img-path}/app-small.svg');
+  }
+}

--- a/src/img/app-small.svg
+++ b/src/img/app-small.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+    <title>block/ui/icon/app-small</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="16" height="16" rx="2"></rect>
+        <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="16" height="16" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+    </defs>
+    <g id="-blocks-components-symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="block/ui/icon/app-small">
+            <g id="block/ui/icon/app">
+                <g id="Group-7">
+                    <use id="Rectangle-442" stroke="#111111" mask="url(#mask-2)" stroke-width="2" fill="#FFFFFF" xlink:href="#path-1"></use>
+                    <polygon id="Polygon-46" fill="#046CD5" points="8 2.5 12.7631397 5.25 12.7631397 10.75 8 13.5 3.23686028 10.75 3.23686028 5.25"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/img/org-small.svg
+++ b/src/img/org-small.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+    <title>block/ui/icon/org-small</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="16" height="16" rx="2"></rect>
+        <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="16" height="16" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <circle id="path-3" cx="5.5" cy="5.5" r="5.5"></circle>
+    </defs>
+    <g id="-blocks-components-symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="block/ui/icon/org-small">
+            <g id="icon/org-small" stroke="#111111" stroke-width="2" fill="#FFFFFF">
+                <use id="Rectangle-442" mask="url(#mask-2)" xlink:href="#path-1"></use>
+            </g>
+            <g id="Group-11" transform="translate(2.500000, 2.500000)">
+                <mask id="mask-4" fill="white">
+                    <use xlink:href="#path-3"></use>
+                </mask>
+                <g id="Oval-90"></g>
+                <polygon id="Polygon-46-Copy-5" fill="#2A3946" mask="url(#mask-4)" points="11.5 2.5 14.0980762 4 14.0980762 7 11.5 8.5 8.90192379 7 8.90192379 4"></polygon>
+                <polygon id="Polygon-46-Copy-6" fill="#2A3946" mask="url(#mask-4)" points="-0.5 2.5 2.09807621 4 2.09807621 7 -0.5 8.5 -3.09807621 7 -3.09807621 4"></polygon>
+                <polygon id="Polygon-46-Copy" fill="#2A3946" mask="url(#mask-4)" points="2.5 -2.5 5.09807621 -1 5.09807621 2 2.5 3.5 -0.0980762114 2 -0.0980762114 -1"></polygon>
+                <polygon id="Polygon-46-Copy-2" fill="#2A3946" mask="url(#mask-4)" points="8.5 -2.5 11.0980762 -1 11.0980762 2 8.5 3.5 5.90192379 2 5.90192379 -1"></polygon>
+                <polygon id="Polygon-46-Copy-4" fill="#2A3946" mask="url(#mask-4)" points="2.5 7.5 5.09807621 9 5.09807621 12 2.5 13.5 -0.0980762114 12 -0.0980762114 9"></polygon>
+                <polygon id="Polygon-46-Copy-3" fill="#2A3946" mask="url(#mask-4)" points="8.5 7.5 11.0980762 9 11.0980762 12 8.5 13.5 5.90192379 12 5.90192379 9"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/img/space-small.svg
+++ b/src/img/space-small.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+    <title>block/ui/icon/space-small</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="16" height="16" rx="2"></rect>
+        <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="16" height="16" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+    </defs>
+    <g id="-blocks-components-symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="block/ui/icon/space-small">
+            <g id="icon/space-small">
+                <g id="Group-6">
+                    <use id="Rectangle-442" stroke="#111111" mask="url(#mask-2)" stroke-width="2" fill="#FFFFFF" xlink:href="#path-1"></use>
+                    <polygon id="Polygon-46" fill="#046CD5" points="8.09807621 3 10.1961524 4.21132487 10.1961524 6.6339746 8.09807621 7.84529946 6 6.6339746 6 4.21132487"></polygon>
+                    <polygon id="Polygon-46-Copy" fill="#046CD5" points="5.09807621 8 7.19615242 9.21132487 7.19615242 11.6339746 5.09807621 12.8452995 3 11.6339746 3 9.21132487"></polygon>
+                    <polygon id="Polygon-46-Copy-2" fill="#046CD5" points="11.0980762 8 13.1961524 9.21132487 13.1961524 11.6339746 11.0980762 12.8452995 9 11.6339746 9 9.21132487"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Part of https://github.com/18F/cg-dashboard/issues/681

The breadcrumbs are available in the staging environment https://dashboard-staging.apps.cloud.gov/

The dashboard code lives on the [adborden/breadcrumb-nav](https://github.com/18F/cg-dashboard/tree/adborden/breadcrumb-nav) branch.

![screenshot from 2016-11-01 16-57-37](https://cloud.githubusercontent.com/assets/509703/19911964/57df0d2a-a054-11e6-88d0-bdb7653fd8af.png)
