### PR TITLE
Fix loading block

### DIFF
--- a/src/css/components/loading.scss
+++ b/src/css/components/loading.scss
@@ -5,7 +5,7 @@ $z-foreground: 200;
   background: white;
   height: 100%;
   left: 0;
-  position: absolute;
+  position: relative;
   top: 0;
   width: 100%;
   z-index: $z-foreground;


### PR DESCRIPTION
The structure of the containers on the dashboard has changed so the layout of the loading box needs to change to accommodate that.

So before, there was a container of the correct width that was position relative. Now based on the way the containers work, they're not the correct width, so this should just be relative.