### PR TITLE
Icons for CF entities

### DIFF
--- a/src/css/components/count_status.scss
+++ b/src/css/components/count_status.scss
@@ -25,6 +25,14 @@
   }
 }
 
+.count_status-icon {
+  float: left;
+}
+
+.count_status-text {
+  float: right;
+}
+
 .count_status-ok,
 .count_status-started,
 .count_status-running {

--- a/src/css/components/icon.scss
+++ b/src/css/components/icon.scss
@@ -6,8 +6,10 @@
   width: 3.9rem;
 
   .icon {
+    height: 100%;
     max-height: 3.1rem;
     max-width: none;
+    width: 100%;
   }
 
   & + h3 {
@@ -17,17 +19,51 @@
 
 .icon {
   display: inline-block;
-  height: 100%;
   fill: transparent;
+  height: 1em;
   max-height: 2rem;
   max-width: 2rem;
+  min-height: 20px;
+  min-width: 20px;
   stroke: currentColor;
   position: relative;
   top: -0.0625rem;
   vertical-align: middle;
-  width: 100%;
+  width: 1em;
 }
 
 .icon-alt {
   stroke: $color-primary-alt-light;
+}
+
+.icon-fill {
+  @extend .icon;
+  fill: currentColor;
+  stroke: transparent;
+
+  &.icon-fill-ok {
+    fill: $color-ok;
+  }
+
+  &.icon-fill-error {
+    fill: $color-error;
+  }
+
+  &.icon-alt {
+    fill: $color-primary-alt-light;
+  }
+}
+
+* + .icon,
+* + .icon-fill {
+  display: inline-block;
+  margin-left: 1rem;
+}
+
+.icon,
+.icon-fill {
+  & + * {
+    display: inline-block;
+    margin-left: 1rem;
+  }
 }

--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -91,7 +91,7 @@ h4 + .panel {
       display: flex;
       margin-top: $vertical-padding;
       padding-bottom: 0;
-      padding-left: $grid-2;
+      padding-left: $grid-4;
     }
   }
 }

--- a/src/img/i-app.svg
+++ b/src/img/i-app.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="14px" viewBox="0 0 12 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
+    <title>app</title>
+    <defs>
+      <style>.cls-1{fill:#fff;stroke:none;}</style>
+    </defs>
+    <g id="Page-1" class="cls-1" fill-rule="evenodd">
+      <polygon class="cls-1" id="Polygon-46" points="1.760722 2.91030866 5.89425976 0.523809524 11.5028052 3.76190476 11.5028052 10.2380952 5.89425976 13.4761905 0.285714286 10.2380952 0.285714286 3.76190476"></polygon>
+    </g>
+</svg>

--- a/src/img/i-org.svg
+++ b/src/img/i-org.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>icon/org-16-textblack</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <circle id="path-1" cx="5.5" cy="5.5" r="5.5"></circle>
+    </defs>
+    <g id="-blocks/icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="icon/org-small--filled">
+            <g id="icon/org-small" fill-rule="evenodd" fill="#333333">
+                <rect id="Rectangle-442" x="0" y="0" width="16" height="16" rx="2"></rect>
+            </g>
+            <g id="Group-11" fill-rule="evenodd" transform="translate(2.500000, 2.500000)">
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <use id="Oval-90" fill="#FFFFFF" xlink:href="#path-1"></use>
+            </g>
+            <path d="M8,2.48865295 L8,13.5104032" id="Line" stroke="#333333" stroke-linecap="square"></path>
+            <path d="M12.7828117,5.25346061 L3.23769607,10.7643357" id="Line-Copy" stroke="#333333" stroke-linecap="square" transform="translate(8.010254, 8.008898) rotate(1.000000) translate(-8.010254, -8.008898) "></path>
+            <path d="M12.7828117,10.7643357 L3.23769607,5.25346061" id="Line-Copy-2" stroke="#333333" stroke-linecap="square"></path>
+            <polygon id="Polygon" stroke="#333333" fill="#FFFFFF" fill-rule="evenodd" points="8 5 10.5980762 6.5 10.5980762 9.5 8 11 5.40192379 9.5 5.40192379 6.5"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/img/i-space.svg
+++ b/src/img/i-space.svg
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="19px" height="20px" viewBox="0 0 19 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="82px" height="78px" viewBox="0 0 82 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
-    <title>space</title>
-    <defs>
-      <style>.cls-1{fill:#fff;stroke:none;}</style>
-      <rect id="path-1" x="0" y="0" width="27.0543686" height="27.2338967" rx="2"></rect>
-    </defs>
-    <g id="Page-1" fill-rule="evenodd">
-      <g id="base/bg-white.border-b1.border-textblack.rounded">
-        <g id="Rectangle-2-Clipped">
-          <mask id="mask-2" fill="white">
-            <use xlink:href="#path-1"></use>
-          </mask>
-          <g id="path-1"></g>
+    <title>space-16-textblack</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="space-16-textblack" transform="translate(-3.000000, -4.000000)" fill="#333333">
+            <g id="icon/space-16-textblack">
+                <g id="-blocks/icons">
+                    <g id="icon/space-small--black">
+                        <g id="icon/space-small">
+                            <g id="Group-6">
+                                <polygon id="Polygon-46" points="43.8047858 4.35 60.4220714 13.9439944 60.4220714 33.1319833 43.8047858 42.7259776 27.1875 33.1319833 27.1875 13.9439944"></polygon>
+                                <polygon id="Polygon-46-Copy" points="19.8797858 43.5 36.4970715 53.0939944 36.4970715 72.2819833 19.8797858 81.875978 3.2625 72.2819833 3.2625 53.0939944"></polygon>
+                                <polygon id="Polygon-46-Copy-2" points="67.7297857 43.5 84.3470714 53.0939944 84.3470714 72.2819833 67.7297857 81.875978 51.1125 72.2819833 51.1125 53.0939944"></polygon>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
         </g>
-      </g>
-      <polygon class="cls-1" id="Polygon-46" points="13.6930212 5.10635563 17.2406541 7.16817415 17.2406541 11.2918112 13.6930212 13.3536297 10.1453882 11.2918112 10.1453882 7.16817415"></polygon>
-      <polygon class="cls-1" id="Polygon-46-Copy" points="8.62032707 13.6169483 12.16796 15.6787669 12.16796 19.8024039 8.62032707 21.8642225 5.07269412 19.8024039 5.07269412 15.6787669"></polygon>
-      <polygon class="cls-1" id="Polygon-46-Copy-2" points="18.7657153 13.6169483 22.3133482 15.6787669 22.3133482 19.8024039 18.7657153 21.8642225 15.2180824 19.8024039 15.2180824 15.6787669"></polygon>
     </g>
 </svg>

--- a/src/img/i-space.svg
+++ b/src/img/i-space.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="19px" height="20px" viewBox="0 0 19 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
+    <title>space</title>
+    <defs>
+      <style>.cls-1{fill:#fff;stroke:none;}</style>
+      <rect id="path-1" x="0" y="0" width="27.0543686" height="27.2338967" rx="2"></rect>
+    </defs>
+    <g id="Page-1" fill-rule="evenodd">
+      <g id="base/bg-white.border-b1.border-textblack.rounded">
+        <g id="Rectangle-2-Clipped">
+          <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+          </mask>
+          <g id="path-1"></g>
+        </g>
+      </g>
+      <polygon class="cls-1" id="Polygon-46" points="13.6930212 5.10635563 17.2406541 7.16817415 17.2406541 11.2918112 13.6930212 13.3536297 10.1453882 11.2918112 10.1453882 7.16817415"></polygon>
+      <polygon class="cls-1" id="Polygon-46-Copy" points="8.62032707 13.6169483 12.16796 15.6787669 12.16796 19.8024039 8.62032707 21.8642225 5.07269412 19.8024039 5.07269412 15.6787669"></polygon>
+      <polygon class="cls-1" id="Polygon-46-Copy-2" points="18.7657153 13.6169483 22.3133482 15.6787669 22.3133482 19.8024039 18.7657153 21.8642225 15.2180824 19.8024039 15.2180824 15.6787669"></polygon>
+    </g>
+</svg>


### PR DESCRIPTION
Such as space, app, org. Includes code that makes it easier to inline
icons rather then the block layout as done on cg-site. To inline an
icon, which is done on dashboard overview page, simply don't use the
icon container and place the icon within the text tag it's next to.

The inlined icon will keep the size of the text tag it's in as it's
height and width are set to 1em. The icon also has a min width/height
though as I found at too small of sizes of text the icon wasn't
rendering very well.

Some of these icons need additional work to receive the border they
have.

This PR addresses separating out fill icons vs regular (or existing)
stroke icons. This has to be done because some of our icons only work
as fills and vice-versa for strokes. The default is just the `icon`
class and is stroke. The `icon-fill` class is for fill icons and will
be colored differently.