### PR TITLE
Removing nested P from activity_log-item_text

### DIFF
--- a/src/css/components/activity_log.scss
+++ b/src/css/components/activity_log.scss
@@ -27,7 +27,7 @@
     position: relative;
   }
 
-  .activity_log-item_text p,
+  .activity_log-item_text,
   .activity_log-item_timestamp {
     font-family: $font-mono;
     font-size: $sans-s3;
@@ -53,7 +53,7 @@
       top: 0;
     }
 
-    .activity_log-item_text p {
+    .activity_log-item_text {
       font-family: $font-sans;
       font-weight: 600;
     }


### PR DESCRIPTION
Removing the nested P as the class name has shifted to the P element.
See https://github.com/18F/cg-dashboard/pull/809