### PR TITLE
Use npm auth token for npm publish on CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_API_TOKEN}

--- a/circle.yml
+++ b/circle.yml
@@ -29,5 +29,4 @@ deployment:
     tag: /[0-9]+(\.[0-9]+)*/
     owner: 18F
     commands:
-      - echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
       - npm run check-publish


### PR DESCRIPTION
I've set the NPM_API_TOKEN env variable in CircleCI with the 18f-devops token.

This avoids
- having to put a user/password in CircleCI.
- risk of leaking secrets when piping input around.