### PR TITLE
Changes to accommodate org overview page

### DIFF
--- a/src/css/base/typography.scss
+++ b/src/css/base/typography.scss
@@ -217,6 +217,11 @@ hr {
   opacity: 1;
 }
 
+.subtext {
+  color: $color-darkgray;
+  font-size: $sans-s2;
+}
+
 @for $i from 1 through length($sans-s) {
   .sans-s#{$i} {
     font-size: nth($sans-s, $i);

--- a/src/css/components/count_status.scss
+++ b/src/css/components/count_status.scss
@@ -5,7 +5,7 @@
 
 .count_status {
   display: inline-block;
-  height: 0.6rem;
+  height: 1.1rem;
   margin-left: $grid-3;
   position: relative;
   width: 7.5rem;

--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -182,6 +182,12 @@ h4 + .panel {
   min-width: 25%;
 }
 
+// TODO rename `-less` to something else
+.panel-column-shrink {
+  flex-grow: 0;
+  margin-right: 2rem;
+}
+
 .panel-new {
   background-color: $color-white;
   margin-top: $grid-4;

--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -61,12 +61,12 @@ h4 + .panel {
 
 .panel-actions {
   display: block;
-  margin-top: 1rem;
+  margin-top: $grid-2;
 }
 
 .panel-actions-right {
   float: right;
-  margin-bottom: -2rem;
+  margin-bottom: $grid-4;
 }
 
 .panel-header {
@@ -108,7 +108,6 @@ h4 + .panel {
     margin: 1rem -1rem -1rem;
     padding: 1rem;
     width: 100%;
-
   }
 
   &:last-child {
@@ -155,7 +154,7 @@ h4 + .panel {
 }
 
 .panel-row-space {
-  margin-top: 1rem;
+  margin-top: $grid-2;
 }
 
 .panel-row-is_clickable {
@@ -205,7 +204,7 @@ h4 + .panel {
 // TODO rename `-less` to something else
 .panel-column-shrink {
   flex-grow: 0;
-  margin-right: 2rem;
+  margin-right: $grid-4;
 }
 
 .panel-new {

--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -59,6 +59,11 @@ h4 + .panel {
   }
 }
 
+.panel-actions {
+  display: block;
+  margin-top: 1rem;
+}
+
 .panel-actions-right {
   float: right;
   margin-bottom: -2rem;
@@ -79,8 +84,15 @@ h4 + .panel {
   }
 }
 
+.panel-row-header {
+  font-size: $sans-s2;
+  font-weight: 700;
+  margin-bottom: $grid-1;
+}
+
 .panel-row {
   $vertical-padding: $grid-105;
+  border-top: 1px solid $color-textblack;
   padding: $vertical-padding 0;
 
   // TODO react problem can't return just rows without wrapped div.
@@ -99,16 +111,20 @@ h4 + .panel {
 
   }
 
-  > .panel-row {
-    border-top: 1px solid $color-textblack;
-    display: block;
+  &:last-child {
+    padding-bottom: 0;
+  }
 
-    > .panel-row {
-      border-top: 1px solid $color-lightgray;
-      display: flex;
-      margin-top: $vertical-padding;
-      padding-bottom: 0;
-      padding-left: $grid-4;
+  > .panel-row {
+    border-top: 1px solid $color-lightgray;
+    display: block;
+    margin-bottom: $vertical-padding;
+    margin-left: $grid-4;
+    margin-top: $vertical-padding;
+    padding-bottom: 0;
+
+    &:last-child {
+      margin-bottom: 0;
     }
   }
 }
@@ -118,10 +134,14 @@ h4 + .panel {
   margin-bottom: $panel-padding;
   padding: $panel-padding;
 
-  &:last-child {
-    margin-bottom: 0;
+  > .panel-row-is_clickable {
+    display: flex;
   }
 
+  &:last-child {
+    margin-bottom: 0;
+    padding-bottom: $panel-padding;
+  }
 }
 
 .panel-row-bordered {


### PR DESCRIPTION
Adds a subtext style, I think @line47 needed this as well. I needed another panel header style for the smaller, bold type for when it's a table. I want to abstract this away at some point but wanted to be sure we have more design ready before doing so. I simplified the panel-row code so certain layout things happen at just two nested levels of panel-rows. This reduces complexity and ensures the space overview and org overview don't need a fake extra panel row. It required adding some extra rules for the overview page, which is related to the boxed panel row.

The panel code still has to be refactored, I wanted to do so when the big PL PR is done, and when we've seen all design. From there, we should look at all the different parts we're using and abstract things away.