### PR TITLE
Add component statuses

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -17,6 +17,33 @@ fractal.set('project.title', 'cloud.gov design system');
 
 fractal.components.set('path', __dirname + '/docs/src/components');
 fractal.components.set('default.preview', '@preview');
+fractal.components.set('statuses', {
+  prototype: {
+    label: "Prototype",
+    description: "Code implementation is in exploratory phase, incomplete and not for use.",
+    color: "#FF3333"
+  },
+  wip: {
+    label: "WIP",
+    description: "Work in progress. Use with caution.",
+    color: "#FF9233"
+  },
+  beta: {
+    label: "Beta",
+    description: "When some design/accessibility reviews have been done and documentation is complete. The component is ready for use.",
+    color: "#056DD4"
+  },
+  ready: {
+    label: "Ready",
+    description: "Accessibility review finished, usability review finished, documentation complete.",
+    color: "#29CC29"
+  },
+  deprecated: {
+    label: "Deprecated",
+    description: "Component exists only for backwards compatibility and will be removed in the near future.",
+    color: "#CCC"
+  }
+});
 
 fractal.docs.set('path', __dirname + '/docs/src/docs');
 


### PR DESCRIPTION
Pulling out the status conversation from https://github.com/18F/cg-style/pull/225. I like @msecret 's [suggestion](https://github.com/18F/cg-style/pull/225#issuecomment-269038074) because it includes statuses that indicate level of design/accessibility review (beta vs ready) which came up in our pattern library sync.

Includes statuses that represent exploratory work (prototype) as well as meeting
some quality of design/accessibility review (ready) or not (beta).

| Status | Description |
| -------- | ---------------- |
| Prototype | Code implementation is in exploratory phase, incomplete and not for use. |
| WIP | Work in progress. Use with caution. |
| Beta | When some design/accessibility reviews have been done and documentation is complete. The component is ready for use. |
| Ready | Accessibility review finished, usability review finished, documentation complete. |
| Deprecated | Component exists only for backwards compatibility and will be removed in the near future. |

![screenshot from 2016-12-23 15-38-13](https://cloud.githubusercontent.com/assets/509703/21463957/af20694e-c926-11e6-888a-625ffa33407a.png)
![screenshot from 2016-12-23 15-38-30](https://cloud.githubusercontent.com/assets/509703/21463960/b7c9d332-c926-11e6-97a7-215ae97fbfa9.png)
![screenshot from 2016-12-23 15-39-04](https://cloud.githubusercontent.com/assets/509703/21463962/bab6e92c-c926-11e6-99c1-c566d1435733.png)

