### PR TITLE
Height of sidenav update

### DIFF
--- a/src/css/components/sidenav.scss
+++ b/src/css/components/sidenav.scss
@@ -25,20 +25,20 @@ $color-heading:     $color-primary-alt-light;
 }
 
 .sidenav {
-  /* stylelint-disable plugin/declaration-block-max-declarations */
+  // stylelint-disable plugin/declaration-block-max-declarations
   align-self: stretch;
   background-color: $color-cream;
   bottom: 0;
   display: none;
   flex-grow: 0;
   flex-shrink: 0;
-  height: 100%;
+  height: auto;
   padding: $grid-3;
   position: absolute;
   top: 0;
   width: 100%;
   z-index: 1;
-  /* stylelint-enable */
+  // stylelint-enable
 
   @include media($medium-screen + $width-nav-sidebar) {
     background-color: transparent;


### PR DESCRIPTION
On pages where the content section is small like “/docs/“ or “contact”
the footer is much father below the content. Removing the height 100% on sidenav
fixes this issue.