### PR TITLE
Align top nav and disclaimer with dashboard width [IGNORE FOR NOW]

### DIFF
--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -16,8 +16,7 @@
   padding-bottom: $grid-3;
 }
 
-// kludge for targeting dashboard
-.js-app {
+.header-wide {
   .header-wrap {
     max-width: 1224px;
     padding-left: $grid-4;

--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -16,6 +16,15 @@
   padding-bottom: $grid-3;
 }
 
+// kludge for targeting dashboard
+.js-app {
+  .header-wrap {
+    max-width: 1224px;
+    padding-left: $grid-4;
+    padding-right: $grid-4;
+  }
+}
+
 .header-title {
   float: left;
   margin-bottom: .6rem;

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -32,6 +32,9 @@
   padding-top: 9px;
 
   .usa-disclaimer-stage {
+    @include media($medium-screen) {
+      display: block;
+    }
     margin-top: 0;
   }
 
@@ -42,6 +45,21 @@
     color: $color-lightgray;
     font-weight: 400;
     text-decoration: underline;
+  }
+}
+
+// kludge for targeting dashboard
+.js-app {
+  .usa-disclaimer {
+    .grid {
+      max-width: 1224px;
+      padding-left: $grid-4;
+      padding-right: $grid-4;
+      @include media($large-screen) {
+        padding-left: $grid-4;
+        padding-right: $grid-4;
+      }
+    }
   }
 }
 

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -49,17 +49,15 @@
 }
 
 // kludge for targeting dashboard
-.js-app {
-  .usa-disclaimer {
-    .grid {
-      max-width: 1224px;
+.disclaimer-wide {
+  .grid {
+    max-width: 1224px;
+    padding-left: $grid-4;
+    padding-right: $grid-4;
+
+    @include media($large-screen) {
       padding-left: $grid-4;
       padding-right: $grid-4;
-
-      @include media($large-screen) {
-        padding-left: $grid-4;
-        padding-right: $grid-4;
-      }
     }
   }
 }

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -55,6 +55,7 @@
       max-width: 1224px;
       padding-left: $grid-4;
       padding-right: $grid-4;
+
       @include media($large-screen) {
         padding-left: $grid-4;
         padding-right: $grid-4;

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -151,3 +151,5 @@ $lh-display:   1.65;
 // border radius
 $rounded:         2px;
 $not-rounded:       0;
+
+$medium-screen: 700px;


### PR DESCRIPTION
**Ignore in favor of dropping the sidebar**

This PR adjusts the padding and max-widths of the disclaimer and the top nav of the dashboard to align their left and right edges with the outside edges of the dashboard content. It adjusts the `$medium-screen` responsive width to better determine when the `disclaimer-stage` text should show. The end result is a cleaner visual presentation of the top of the page.

This affects only dashboard with a kludgey style hook: `.js-app`. I used this hook only because it was an existing class that is unique to the dashboard. We could apply a better hook, perhaps at the `body` level, but I didn't want to touch `cg-dashboard`. 

Can someone help me determine where to put this style hook and what it should be?

- - -

![screen shot 2016-12-29 at 10 45 59 am](https://cloud.githubusercontent.com/assets/11464021/21552150/86d36670-cdb4-11e6-9657-2b21d6dd182a.png)
