### PR TITLE
Correcting typo

### DIFF
--- a/docs/src/components/base/layout/layout.html
+++ b/docs/src/components/base/layout/layout.html
@@ -116,7 +116,7 @@
 </div>
 
 <h2>Flex layout</h2>
-<p class="subhed sans-s6 fw700 lh-cap textblack">The flex layout has no max width and can be mixed and nested as necessary. The total numnber of columns is  simple of the sum of the <span class="font-mono fw300 mono-s6">-f#</span>s. Items in a <span class="font-mono fw300 mono-s6">.row</span> are top aligned by default.</p>
+<p class="subhed sans-s6 fw700 lh-cap textblack">The flex layout has no max width and can be mixed and nested as necessary. The total number of columns is simple of the sum of the <span class="font-mono fw300 mono-s6">-f#</span>s. Items in a <span class="font-mono fw300 mono-s6">.row</span> are top aligned by default.</p>
 <div class="flex-grid">
   <div class="row">
     <div class="coltest col-f1">


### PR DESCRIPTION
Small typo fix `numnber`>`number` and remove an additional space, though I believe the sentence is missing a word where the extra space occurred.

Thanks for the demo today, @thisisdano !

**Screenshot of errors:**

<img width="613" alt="screen shot 2016-12-29 at 2 11 05 pm" src="https://cloud.githubusercontent.com/assets/11636908/21555431/11c4f52e-cde6-11e6-8da9-72873f6eb7eb.png">


Hope I targeted the right branch, if not, feel free to redirect.