### PR TITLE
Goodbye sidebar! (Styles to make this work)

### DIFF
--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -10,10 +10,16 @@
   @include clearfix;
   margin: 0 auto;
   max-width: $site-max-width;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: $grid-2;
+  padding-right: $grid-2;
   padding-top: $grid-5;
   padding-bottom: $grid-3;
+}
+
+.header-dashboard {
+  .header-wrap {
+    max-width: $dashboard-max-width;
+  }
 }
 
 .header-title {

--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -18,7 +18,7 @@
 
 .header-no_sidebar {
   .header-wrap {
-    max-width: $dashboard-no_sidebar;
+    max-width: $no-sidebar-max-width;
   }
 }
 

--- a/src/css/components/header.scss
+++ b/src/css/components/header.scss
@@ -10,15 +10,15 @@
   @include clearfix;
   margin: 0 auto;
   max-width: $site-max-width;
+  padding-bottom: $grid-3;
   padding-left: $grid-2;
   padding-right: $grid-2;
   padding-top: $grid-5;
-  padding-bottom: $grid-3;
 }
 
-.header-dashboard {
+.header-no_sidebar {
   .header-wrap {
-    max-width: $dashboard-max-width;
+    max-width: $dashboard-no_sidebar;
   }
 }
 
@@ -30,8 +30,8 @@
 .header-side {
 
   float: left;
-  width: 100%;
   position: relative;
+  width: 100%;
 
   @include media($medium-screen) {
 

--- a/src/css/components/main-content.scss
+++ b/src/css/components/main-content.scss
@@ -13,14 +13,14 @@
 }
 
 .main_content {
-  &.content-dashboard {
+  &.content-no_sidebar {
     margin: 0 auto;
-    max-width: $dashboard-max-width;
+    max-width: $dashboard-no_sidebar;
     padding: 0 $grid-2;
   }
 }
 
-.content-dashboard {
+.content-no_sidebar {
   .content {
     margin: 0;
     max-width: none;

--- a/src/css/components/main-content.scss
+++ b/src/css/components/main-content.scss
@@ -15,7 +15,7 @@
 .main_content {
   &.content-no_sidebar {
     margin: 0 auto;
-    max-width: $dashboard-no_sidebar;
+    max-width: $no-sidebar-max-width;
     padding: 0 $grid-2;
   }
 }

--- a/src/css/components/main-content.scss
+++ b/src/css/components/main-content.scss
@@ -11,3 +11,24 @@
     padding: $grid-4;
   }
 }
+
+.main_content {
+  &.content-dashboard {
+    margin: 0 auto;
+    max-width: $dashboard-max-width;
+    padding: 0 $grid-2;
+  }
+}
+
+.content-dashboard {
+  .content {
+    margin: 0;
+    max-width: none;
+    padding: $grid-4 0;
+    width: auto;
+  }
+
+  .grid {
+    max-width: none;
+  }
+}

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -54,6 +54,13 @@
   }
 }
 
+.disclaimer-dashboard {
+  .grid {
+    max-width: $dashboard-max-width;
+    padding: 0 $grid-2;
+  }
+}
+
 .usa-sidenav-list {
   margin-left: -$grid-1;
 

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -54,9 +54,9 @@
   }
 }
 
-.disclaimer-dashboard {
+.disclaimer-no_sidebar {
   .grid {
-    max-width: $dashboard-max-width;
+    max-width: $dashboard-no_sidebar;
     padding: 0 $grid-2;
   }
 }

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -56,7 +56,7 @@
 
 .disclaimer-no_sidebar {
   .grid {
-    max-width: $dashboard-no_sidebar;
+    max-width: $no-sidebar-max-width;
     padding: 0 $grid-2;
   }
 }

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -99,7 +99,7 @@ $grid-n5:             #{($grid-base * -5 / $grid-type)}rem;     // 40px
 // widths
 $nav-width:             $grid-base-px * 75;          // 600px;
 $site-max-width:        $grid-base-px * 130;         // 1040px;
-$dashboard-no_sidebar:   $grid-base-px * 111;         // 888px;
+$no-sidebar-max-width:   $grid-base-px * 111;         // 888px;
 $text-max-width:        36em;
 $text-narrow-width:     17em;
 

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -97,10 +97,11 @@ $grid-n4:             #{($grid-base * -4 / $grid-type)}rem;     // 32px
 $grid-n5:             #{($grid-base * -5 / $grid-type)}rem;     // 40px
 
 // widths
-$nav-width:          $grid-base-px * 75;          // 600px;
-$site-max-width:     $grid-base-px * 130;         // 1040px;
-$text-max-width:     36em;
-$text-narrow-width:  17em;
+$nav-width:             $grid-base-px * 75;          // 600px;
+$site-max-width:        $grid-base-px * 130;         // 1040px;
+$dashboard-max-width:   $grid-base-px * 111;         // 888px;
+$text-max-width:        36em;
+$text-narrow-width:     17em;
 
 // type scale
 $sans-s1:           (10rem / $grid-type);         // 10px;

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -99,7 +99,7 @@ $grid-n5:             #{($grid-base * -5 / $grid-type)}rem;     // 40px
 // widths
 $nav-width:             $grid-base-px * 75;          // 600px;
 $site-max-width:        $grid-base-px * 130;         // 1040px;
-$dashboard-max-width:   $grid-base-px * 111;         // 888px;
+$dashboard-no_sidebar:   $grid-base-px * 111;         // 888px;
 $text-max-width:        36em;
 $text-narrow-width:     17em;
 


### PR DESCRIPTION
These style help regularize the widths of dashboard elements if there's no sidebar.

**Paired with https://github.com/18F/cg-dashboard/pull/893**
**Based off Icon/Panel work in https://github.com/18F/cg-dashboard/pull/892 and https://github.com/18F/cg-style/pull/250 — Merge them first.**

- - -

![screen shot 2016-12-30 at 7 27 00 am](https://cloud.githubusercontent.com/assets/11464021/21567502/72e13220-ce61-11e6-9c3e-9daa63920004.png)

- - -

![screen shot 2016-12-30 at 7 27 18 am](https://cloud.githubusercontent.com/assets/11464021/21567504/767fc0cc-ce61-11e6-9e1d-f647217bcd49.png)
