### PR TITLE
Style changes for header, breadcrumb,  and actions

### DIFF
--- a/src/css/components/actions.scss
+++ b/src/css/components/actions.scss
@@ -6,7 +6,7 @@
 
 .action-link {
   color: $color-blue;
-  font-size: $sans-s2;
+  font-size: $sans-s3;
   font-weight: bold;
   text-decoration: underline;
 
@@ -19,9 +19,6 @@
 
 // Extra specificity due to WDS.
 .action {
-  &.action-primary {
-    font-size: $sans-s2;
-  }
 
   &.action-cautious {
     background-color: $color-lightgray;
@@ -35,7 +32,6 @@
       background-color: transparent;
       box-shadow: inset 0 0 0 1px $color-lightgray;
       color: $color-lightgray;
-      font-size: $sans-s2;
     }
   }
 

--- a/src/css/components/breadcrumbs.scss
+++ b/src/css/components/breadcrumbs.scss
@@ -6,7 +6,8 @@
   @extend %fw400;
   @extend %sans-s5;
   @extend %lh-single;
-  @extend %mb2;
+  @extend %mb4;
+  @extend %mtn2;
 }
 
 .breadcrumbs-item {

--- a/src/css/components/breadcrumbs.scss
+++ b/src/css/components/breadcrumbs.scss
@@ -3,25 +3,31 @@
 @import '../core.scss';
 
 .breadcrumbs {
-  font-size: $sans-s3;
-  line-height: $lh-single;
-  margin: 0 $grid-3 $grid-3;
+  @extend %fw400;
+  @extend %sans-s5;
+  @extend %lh-single;
+  @extend %mb2;
 }
 
 .breadcrumbs-item {
-  display: inline-block;
+  @extend %inline-block;
 
   // Breadcrumb separator
   &::after {
-    color: $color-lightgray;
+    color: $color-mediumgray-trans;
     content: '/';
     display: inline;
     font-size: $sans-s6;
     line-height: $lh-single;
     padding: 0 $grid-1;
+    position: relative;
+    top: 2px;
   }
 }
 
+.breadcrumbs-item-link,
 .breadcrumbs-item-link_text {
-  text-decoration: underline;
+  @extend %bb1px;
+  @extend %inline-block;
+  padding-bottom: .15em;
 }

--- a/src/css/components/breadcrumbs.scss
+++ b/src/css/components/breadcrumbs.scss
@@ -26,8 +26,7 @@
   }
 }
 
-.breadcrumbs-item-link,
-.breadcrumbs-item-link_text {
+.breadcrumbs-item-link {
   @extend %bb1px;
   @extend %inline-block;
   padding-bottom: .15em;

--- a/src/css/components/breadcrumbs.scss
+++ b/src/css/components/breadcrumbs.scss
@@ -3,15 +3,15 @@
 @import '../core.scss';
 
 .breadcrumbs {
-  @extend %fw400;
-  @extend %sans-s5;
-  @extend %lh-single;
-  @extend %mb4;
-  @extend %mtn2;
+  font-size: $sans-s5;
+  font-weight: 400;
+  line-height: $lh-single;
+  margin-bottom: $grid-4;
+  margin-top: -$grid-2;
 }
 
 .breadcrumbs-item {
-  @extend %inline-block;
+  display: inline-block;
 
   // Breadcrumb separator
   &::after {
@@ -27,7 +27,7 @@
 }
 
 .breadcrumbs-item-link {
-  @extend %bb1px;
-  @extend %inline-block;
+  border-bottom: 1px solid;
+  display: inline-block;
   padding-bottom: .15em;
 }

--- a/src/css/components/card.scss
+++ b/src/css/components/card.scss
@@ -30,4 +30,8 @@
   font-size: $sans-s8;
   font-weight: 400;
   line-height: $lh-single;
+
+  .icon-medium {
+    margin-right: $grid-05;
+  }
 }

--- a/src/css/components/contents.scss
+++ b/src/css/components/contents.scss
@@ -12,6 +12,10 @@
   .icon-bordered {
     top: -2px;
   }
+
+  .icon-medium {
+    margin-right: $grid-05;
+  }
 }
 
 .contents-path {

--- a/src/css/components/loading.scss
+++ b/src/css/components/loading.scss
@@ -2,7 +2,7 @@
 $z-foreground: 200;
 
 .loading {
-  height: 100%;
+  height: 50%;
   left: 0;
   position: relative;
   top: 0;

--- a/src/css/components/loading.scss
+++ b/src/css/components/loading.scss
@@ -2,7 +2,6 @@
 $z-foreground: 200;
 
 .loading {
-  background: white;
   height: 100%;
   left: 0;
   position: relative;
@@ -20,8 +19,8 @@ $indicator-size: 3.5rem;
 .loading-indicator {
   left: calc(50% - #{$indicator-size});
   position: absolute;
-  top: 10rem;
-  width: 3.5rem;
+  top: calc(50% - #{$indicator-size});
+  width: $indicator-size;
 }
 
 .loading-inactive {

--- a/src/css/components/main-content.scss
+++ b/src/css/components/main-content.scss
@@ -17,6 +17,7 @@
     margin: 0 auto;
     max-width: $no-sidebar-max-width;
     padding: 0 $grid-2;
+    width: auto;
   }
 }
 

--- a/src/css/components/nav.scss
+++ b/src/css/components/nav.scss
@@ -19,7 +19,7 @@
   .action {
     &.usa-button-outline {
       margin: -.25rem 0 0 0;
-      padding: .625rem 1rem;
+      padding: .55rem 1rem;
     }
   }
 }

--- a/src/css/components/page_header.scss
+++ b/src/css/components/page_header.scss
@@ -10,7 +10,7 @@
   @extend %col-fill;
 
   .icon-large {
-    top: -4px;
+    top: -3px;
   }
 }
 

--- a/src/css/components/page_header.scss
+++ b/src/css/components/page_header.scss
@@ -8,6 +8,10 @@
 
 .page-header-title {
   @extend %col-fill;
+
+  .icon-large {
+    top: -4px;
+  }
 }
 
 .page-header-actions {

--- a/src/css/components/page_header.scss
+++ b/src/css/components/page_header.scss
@@ -2,12 +2,12 @@
 @import '../core.scss';
 
 .page-header {
-  @extend %row;
+  display: flex;
   margin: 0 0 $grid-4;
 }
 
 .page-header-title {
-  @extend %col-fill;
+  flex: 1;
 
   .icon-large {
     top: -3px;
@@ -15,6 +15,6 @@
 }
 
 .page-header-actions {
-  @extend %col-fit;
+  flex: none;
   margin-right: -$grid-1;
 }

--- a/src/css/components/page_header.scss
+++ b/src/css/components/page_header.scss
@@ -3,7 +3,7 @@
 
 .page-header {
   @extend %row;
-  margin: 0 $grid-3 $grid-3;
+  margin: 0 0 $grid-4;
 }
 
 .page-header-title {
@@ -12,4 +12,5 @@
 
 .page-header-actions {
   @extend %col-fit;
+  margin-right: -$grid-1;
 }

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -193,3 +193,9 @@ input:focus {
     width: $grid-4;
   }
 }
+
+.usa-disclaimer-stage {
+  @include media($medium-screen) {
+    display: block;
+  }
+}

--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -109,6 +109,7 @@ button,
   font-size: $sans-s3;
   font-weight: 500;
   height: $grid-4;
+  margin: $grid-1 $grid-1 $grid-1 0;
   min-width: 6rem;
   padding: 0 $grid-2;
   text-decoration: none;


### PR DESCRIPTION
A few changes to improve appearance of the view header, overview panel, breadcrumbs, and actions...

- improves alignment and spacing in the header and breadcrumbs
- fixes a size error for action buttons
- fixes icon margin in the overview tree
- refines position/background of the loading indicator (but this still needs work in subsequent PRs)

**The breadcrumb will look a little funky until we see the changes in https://github.com/18F/cg-dashboard/issues/912**

- - -

![screen shot 2017-01-04 at 10 20 57 am](https://cloud.githubusercontent.com/assets/11464021/21653868/1db4df44-d268-11e6-9ec9-9d278b6d3f22.png)
