### PR TITLE
Panel group style tweaks

### DIFF
--- a/docs/src/components/features/panel/panel.html
+++ b/docs/src/components/features/panel/panel.html
@@ -5,7 +5,7 @@
     <div class="panel-rows">
         <section class="panel-group">
             <header class="panel-header">
-                <h2>Group header</h2>
+                <h2 class="panel-row-header">Group header</h2>
                 <span>Secondary information</span>
             </header>
             <div class="panel-row">

--- a/src/css/components/panel.scss
+++ b/src/css/components/panel.scss
@@ -67,6 +67,10 @@ h4 + .panel {
 
 .panel-group {
   margin-bottom: 0.65rem;
+
+  & + .panel-group {
+    margin-top: $grid-4;
+  }
 }
 
 .panel-actions {


### PR DESCRIPTION
- added space between panel groups

Looks like this: 

![screen shot 2017-01-04 at 2 29 03 pm](https://cloud.githubusercontent.com/assets/11464021/21661663/31d54dd4-d28a-11e6-8482-ceef8f7e5e84.png)
