### PR TITLE
Update statuses for entity health

### DIFF
--- a/docs/src/components/components/status/README.md
+++ b/docs/src/components/components/status/README.md
@@ -1,12 +1,23 @@
 
 # Status
 
-The **status** component is a way to style test for statuses releated to CloudFoundry
-apps or other status messages. The most common use case is to wrap a CloudFoundry
-app `state` message in the appropriate status component. Additional, the status
-component will captialize it's text to ensure consistency in status messages.
+The **status** component is used throughout the app to indicate a status of
+severity. They are used to assign a status related to CloudFoundry application
+health or other status messages. Additionally, the status component will
+capitalize it's text to ensure consistency in status messages.
+
+| Status   | Description                                                    |
+| ------   | -----------                                                    |
+| inactive | Neutral state.                                                 |
+| ok       | Things are at their best.                                      |
+| warning  | Something is not right, might want to call attention.          |
+| error    | Something is definitely not right and requires some attention. |
+
 
 ## Use
 
 To use the **status** component, wrap the status message in any text tag, `span`,
-`p`, `h`, with the `status` class and any approirate modifer `status` class.
+`p`, `h`, with the `status` class and any appropriate modifier `status` class.
+
+There are some "helper" modifiers that map to four core statuses for
+convenience. For example, common application state values are mapped.

--- a/docs/src/components/components/status/status.config.yml
+++ b/docs/src/components/components/status/status.config.yml
@@ -1,40 +1,17 @@
 title: Status
 status: beta
 collated: true
-default: started
+default: inactive
 variants:
-  - name: started
-    context:
-      text: "started"
-      modifier: started
-      patternbreak: "<br/>"
-  - name: running
-    context:
-      text: "running"
-      modifier: running
-      patternbreak: "<br/>"
-  - name: ok
-    context:
-      text: "ok"
-      modifier: ok
-      patternbreak: "<br/>"
-  - name: stopped
-    context:
-      text: "stopped"
-      modifier: stopped
-      patternbreak: "<br/>"
   - name: inactive
     context:
-      text: "inactive"
       modifier: inactive
-      patternbreak: "<br/>"
-  - name: crashed
+  - name: ok
     context:
-      text: "crashed"
-      modifier: crashed
-      patternbreak: "<br/>"
+      modifier: ok
+  - name: warning
+    context:
+      modifier: warning
   - name: error
     context:
-      text: "error"
       modifier: error
-      patternbreak: "<br/>"

--- a/docs/src/components/components/status/status.html
+++ b/docs/src/components/components/status/status.html
@@ -1,2 +1,2 @@
 
-<span class="status status-{{ modifier }}">{{ text }}</span>
+<span class="status status-{{ modifier }}">{{ text or modifier }}</span></br>

--- a/src/css/components/status.scss
+++ b/src/css/components/status.scss
@@ -18,6 +18,11 @@
   color: $color-inactive;
 }
 
+.status-warning {
+  color: $color-gold;
+}
+
+.status-unknown,
 .status-crashed,
 .status-error {
   color: $color-error;


### PR DESCRIPTION
Update the docs for Status. I spoke with @line47 and there is an underlying pattern we refer to as Status which is independent of Cloud Foundry application state. This pattern should be documented to be more generalized and then we can apply them to other contexts, like application health or activity logs.