### PR TITLE
Refined status grid prototype with sample prototype docs

### DIFF
--- a/docs/src/components/components/icon-square/icon-square.config.yml
+++ b/docs/src/components/components/icon-square/icon-square.config.yml
@@ -493,6 +493,42 @@ variants:
       iconKind: service
       iconSize: large
       isBorder: true
+  - name: service-ok-small
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: small
+      isBorder: true
+  - name: service-ok-medium
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: medium
+      isBorder: true
+  - name: service-ok-large
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: large
+      isBorder: true
+  - name: service-ok-small-reverse
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: small
+      isReverse: true
+  - name: service-ok-medium-reverse
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: medium
+      isReverse: true
+  - name: service-ok-large-reverse
+    context:
+      iconStatus: ok
+      iconKind: service
+      iconSize: large
+      isReverse: true
   - name: service-small-reverse
     context:
       iconKind: service

--- a/docs/src/components/features/count-status-grid/README.md
+++ b/docs/src/components/features/count-status-grid/README.md
@@ -1,3 +1,33 @@
 # Count Status Grid
 
-Needs documentation...
+### Why is this pattern needed?
+A more descriptive count status would give a better quick read of the status of entities within a parent. It would more clearly show the number of entities in error.
+
+### Description
+This is a prototype for a more descriptive count status. It displays bars equal to the count of the specific entity (space, app, service) and color-codes by `error` and `ok` status for apps and services. The icon is red if there are errors, otherwise it is green.
+
+Spaces are shown as black bars with a black icon.
+
+If there are none of a specific `entityType`, the count status gets a single cream-colored bar and the icon is black.
+
+### Variables
+This component accepts the following values:
+- **entityType** (the kind of entity; `service`, `app`, or `space`)
+- **entityCount** (the number of entities in the parent container)
+- **errors** (the number of entities in an error state)
+
+### Variants shown
+- **default** A space count 
+- **app-none** An app count with no apps
+- **app-ok** An app count with no apps in error
+- **app-error** An app count with some apps in error
+- **app-error-xxl** An app count with many apps in the parent
+- **service-none** A service count with no services
+- **service-ok** A service count with no services in error
+- **service-error** A service count with some services in error
+
+### Known issues
+The pattern begins to break down at ~20 entities, when the bars get very narrow.
+
+### Additional elements for development
+None

--- a/docs/src/components/features/count-status-grid/README.md
+++ b/docs/src/components/features/count-status-grid/README.md
@@ -17,7 +17,8 @@ This component accepts the following values:
 - **errors** (the number of entities in an error state)
 
 ### Variants shown
-- **default** A space count 
+- **default** A space count of 1
+- **space** A multiple space count
 - **app-none** An app count with no apps
 - **app-ok** An app count with no apps in error
 - **app-error** An app count with some apps in error

--- a/docs/src/components/features/count-status-grid/count-status-grid.config.yml
+++ b/docs/src/components/features/count-status-grid/count-status-grid.config.yml
@@ -1,42 +1,47 @@
 title: count-status-grid
 status: prototype
 context:
-  entityKind: space
+  entityType: space
   status: alt
   entityCount: 1
 variants:
   - name: default
   - name: space
     context:
-      entityKind: space
+      entityType: space
       entityCount: 3
+  - name: app-none
+    context:
+      entityType: app
+      entityCount: 0
+      errors: 0
   - name: app-ok
     context:
-      entityKind: app
+      entityType: app
       entityCount: 4
       errors: 0
   - name: app-error
     context:
-      entityKind: app
+      entityType: app
       entityCount: 6
       errors: 2
-  - name: app-error-packed
+  - name: app-error-xxl
     context:
-      entityKind: app
+      entityType: app
       entityCount: 16
       errors: 1
   - name: service-none
     context:
-      entityKind: service
+      entityType: service
       entityCount: 0
       errors: 0
   - name: service-ok
     context:
-      entityKind: service
+      entityType: service
       entityCount: 3
       errors: 0
   - name: service-error
     context:
-      entityKind: service
+      entityType: service
       entityCount: 3
       errors: 2

--- a/docs/src/components/features/count-status-grid/count-status-grid.config.yml
+++ b/docs/src/components/features/count-status-grid/count-status-grid.config.yml
@@ -3,21 +3,40 @@ status: prototype
 context:
   entityKind: space
   status: alt
-  entityCount: '1'
+  entityCount: 1
 variants:
   - name: default
   - name: space
     context:
       entityKind: space
-      status: alt
-      entityCount: '3'
-  - name: app
+      entityCount: 3
+  - name: app-ok
     context:
       entityKind: app
-      status: error
-      entityCount: '6'
-  - name: service
+      entityCount: 4
+      errors: 0
+  - name: app-error
+    context:
+      entityKind: app
+      entityCount: 6
+      errors: 2
+  - name: app-error-packed
+    context:
+      entityKind: app
+      entityCount: 16
+      errors: 1
+  - name: service-none
     context:
       entityKind: service
-      status: alt
-      entityCount: '0'
+      entityCount: 0
+      errors: 0
+  - name: service-ok
+    context:
+      entityKind: service
+      entityCount: 3
+      errors: 0
+  - name: service-error
+    context:
+      entityKind: service
+      entityCount: 3
+      errors: 2

--- a/docs/src/components/features/count-status-grid/count-status-grid.html
+++ b/docs/src/components/features/count-status-grid/count-status-grid.html
@@ -1,23 +1,23 @@
 <div class="sans-s4 lh-single w15 ml3 col-fit row-center-x pos-relative">
   <div class="col-fit">
-    {% if entityKind == 'space' or entityCount === 0 %}
-      {% set iconVariant = entityKind + '-medium' %}
+    {% if entityType == 'space' or entityCount === 0 %}
+      {% set iconVariant = entityType + '-medium' %}
     {% else %}
       {% if errors === 0 %}
         {% set status = 'ok' %}
       {% else %}
         {% set status = 'error' %}
       {% endif %}
-      {% set iconVariant = entityKind + '-' + status + '-medium' %}
+      {% set iconVariant = entityType + '-' + status + '-medium' %}
     {% endif %}
     {% render '@icon-square--' + iconVariant %}
   </div>
   <div class="count_status-text col-fill">
     <strong>{{ entityCount }}</strong>
-    {{ entityKind }}{% if entityCount != '1' %}s{% endif %}
+    {{ entityType }}{% if entityCount != '1' %}s{% endif %}
   </div>
   <div class="statusbar pos-absolute bottom-n3 h1 left-0 right-0 mrn1px row bg-cream">
-    {% if entityKind === 'space' %}
+    {% if entityType === 'space' %}
       {% for i in range(0, entityCount) %}
         <span class="bar col-f1 br1px b-white h1 bg-textblack"></span>
       {% endfor %}

--- a/docs/src/components/features/count-status-grid/count-status-grid.html
+++ b/docs/src/components/features/count-status-grid/count-status-grid.html
@@ -1,8 +1,13 @@
 <div class="sans-s4 lh-single w15 ml3 col-fit row-center-x pos-relative">
   <div class="col-fit">
-    {% if status == 'alt' %}
+    {% if entityKind == 'space' or entityCount === 0 %}
       {% set iconVariant = entityKind + '-medium' %}
     {% else %}
+      {% if errors === 0 %}
+        {% set status = 'ok' %}
+      {% else %}
+        {% set status = 'error' %}
+      {% endif %}
       {% set iconVariant = entityKind + '-' + status + '-medium' %}
     {% endif %}
     {% render '@icon-square--' + iconVariant %}
@@ -12,20 +17,17 @@
     {{ entityKind }}{% if entityCount != '1' %}s{% endif %}
   </div>
   <div class="statusbar pos-absolute bottom-n3 h1 left-0 right-0 mrn1px row bg-cream">
-    {# for i in range(0, appsErrors|length) #}
-      {# display a red bar #}
-      <span class="bar col-f1 mr1px h1 bg-red"></span>
-    {# endfor #}
-    {# for i in range(0, appsStopped|length) #}
-      {# display a black bar #}
-      <span class="bar col-f1 mr1px h1 bg-textblack"></span>
-      <span class="bar col-f1 mr1px h1 bg-textblack"></span>
-    {# endfor #}
-    {# for i in range(0, appsErrors|length) #}
-      {# display a green bar #}
-      <span class="bar col-f1 mr1px h1 bg-green"></span>
-      <span class="bar col-f1 mr1px h1 bg-green"></span>
-      <span class="bar col-f1 mr1px h1 bg-green"></span>
-    {# endfor #}
+    {% if entityKind === 'space' %}
+      {% for i in range(0, entityCount) %}
+        <span class="bar col-f1 br1px b-white h1 bg-textblack"></span>
+      {% endfor %}
+    {% else %}
+      {% for i in range(0, errors) %}
+        <span class="bar col-f1 br1px b-white h1 bg-red"></span>
+      {% endfor %}
+      {% for i in range(0, entityCount - errors) %}
+        <span class="bar col-f1 br1px b-white h1 bg-green"></span>
+      {% endfor %}
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
I fixed up my `count-status-grid` prototype to be a better example of delivering a prototype — with better logic and documentation.

@line47 thoughts? (esp on documentation...)

![screen shot 2017-01-04 at 4 03 26 pm](https://cloud.githubusercontent.com/assets/11464021/21663803/540b7b28-d297-11e6-99a5-f1d67b2762c9.png)
