### PR TITLE
Add outer container neat back to grid

### DIFF
--- a/src/css/components/grid.scss
+++ b/src/css/components/grid.scss
@@ -1,4 +1,5 @@
 .grid {
+  @include outer-container;
   margin-left: auto;
   margin-right: auto;
   padding: 0 $gutter;


### PR DESCRIPTION
Removing this breaks the grid because it removes the max width. I
checked this change on dashboard and site and seems to work.