### PR TITLE
Refactor usage and limits

### DIFF
--- a/src/css/components/page_header.scss
+++ b/src/css/components/page_header.scss
@@ -16,6 +16,7 @@
 
 .page-header-title {
   flex: 1;
+  min-width: 26rem;
 
   .icon-large {
     top: -3px;
@@ -26,4 +27,8 @@
   display: flex;
   flex-direction: row;
   margin-right: -$grid-1;
+
+  .error-inline {
+    width: auto;
+  }
 }

--- a/src/css/components/panel-dep.scss
+++ b/src/css/components/panel-dep.scss
@@ -30,6 +30,10 @@ $panel-padding: $grid-3;
   display: flex;
   justify-content: space-between;
   padding-bottom: $grid-1;
+
+  .error-inline {
+    width: auto;
+  }
 }
 
 .panel-row-header {

--- a/src/css/components/panel-dep.scss
+++ b/src/css/components/panel-dep.scss
@@ -13,6 +13,10 @@ $panel-padding: $grid-3;
 
 .panel-group {
   @include clearfix;
+}
+
+.panel-section {
+  @include clearfix;
 
   margin-bottom: 0.65rem;
 

--- a/src/css/components/stat.scss
+++ b/src/css/components/stat.scss
@@ -6,15 +6,14 @@
 $input-font-size: $sans-s2;
 
 .stat {
-  align-items: center;
+  @include clearfix;
   border-left-color: transparent;
   border-left-style: solid;
   border-left-width: 0;
-  display: flex;
-  justify-content: space-between;
+  margin-top: 0.625rem;
   min-height: 2.5rem; // Leave some space for input element when editing a stat
   position: relative;
-  width: 100%;
+  width: 14rem;
 
   .error_message {
     font-size: $input-font-size;
@@ -28,18 +27,30 @@ h5 + .stat {
 .stat-header {
   font-size: $sans-s3;
   font-weight: 900;
-  margin-bottom: $grid-1;
+  margin-bottom: $grid-105;
+}
+
+.stat-group {
+  display: flex;
+
+  & + .stat-group {
+    margin-top: 1.75rem;
+  }
 }
 
 .stat-error,
 .stat-warning,
 .stat-success {
-
   padding-left: $grid-2;
 
   &::before {
     @extend .status-pill;
-    height: 100%;
+    height: 2.5rem;
+    top: 1.25rem;
+  }
+
+  .stat-header {
+    margin-left: -$grid-2;
   }
 }
 
@@ -62,22 +73,41 @@ h5 + .stat {
 }
 
 .stat-info {
+  float: right;
   font-size: $sans-s2;
   font-weight: 600;
   margin-right: $grid-1;
+  margin-top: 0.2rem;
+  width: 8rem;
 }
 
 .stat-primary {
+  float: left;
   font-size: $sans-s6;
+  min-height: 2rem;
   white-space: nowrap;
+  width: 4rem;
 }
 
 .stat-single_box {
   $v-space: $grid-2;
   background-color: $color-lightestgray;
   margin: -$v-space 1.8rem;
+  min-height: 10rem;
   padding: $v-space 0;
+  position: relative;
   text-align: center;
+
+  .stat-info,
+  .stat-primary {
+    float: none;
+  }
+}
+
+.stat-bottom {
+  bottom: 1rem;
+  left: 2%;
+  position: absolute;
 }
 
 // Double classes to compete with specificity over input elements
@@ -87,6 +117,8 @@ h5 + .stat {
     display: inline;
     font-size: $input-font-size;
     margin: 0;
+    padding-bottom: 0.3rem;
+    padding-top: 0.3rem;
     width: 6rem;
     // stylelint-enable
   }


### PR DESCRIPTION
By removing panel code and making the stat component much more
specific. Rather then making the stat component able to adapt
to many different sizes, it sets all the sizes of things. This
makes it much easier to build and I'm not sure the adaptability
will be required for this component anyway.