### PR TITLE
Fix color contrast issues in text

### DIFF
--- a/src/css/components/contents.scss
+++ b/src/css/components/contents.scss
@@ -19,5 +19,5 @@
 }
 
 .contents-path {
-  color: $color-mediumgray;
+  color: $color-darkgray;
 }

--- a/src/css/components/status.scss
+++ b/src/css/components/status.scss
@@ -10,7 +10,7 @@
 .status-started,
 .status-running,
 .status-ok {
-  color: $color-ok;
+  color: $color-textok;
 }
 
 .status-stopped,

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -5,7 +5,8 @@ $color-blue:                    #056dd4;
 $color-brightmint:              #00df99;
 $color-cream:                   #f5f5f3;
 $color-gold:                    #f4b400;
-$color-green:                   #438500;
+$color-textgreen:               #438500;
+$color-green:                   #0baf00;
 $color-red:                     #be4900;
 
 $color-trueblack:               #000000;
@@ -38,6 +39,7 @@ $color-warning:                 $color-red;
 $color-error:                   $color-red;
 $color-finish:                  $color-green;
 $color-ok:                      $color-green;
+$color-textok:                  $color-textgreen;
 $color-inactive:                $color-textblack;
 
 $color-visited:                 $color-blue;

--- a/src/css/override_vars.scss
+++ b/src/css/override_vars.scss
@@ -5,7 +5,7 @@ $color-blue:                    #056dd4;
 $color-brightmint:              #00df99;
 $color-cream:                   #f5f5f3;
 $color-gold:                    #f4b400;
-$color-green:                   #0baf00; // dark option #438500
+$color-green:                   #438500;
 $color-red:                     #be4900;
 
 $color-trueblack:               #000000;


### PR DESCRIPTION
The success button green is too light and the gray for the paths
in the quicklooks is too light of a gray.

Dano mentioned he wanted a different solution for the green but I
think we should fix accessibility issues as soon as possible.

Refs https://github.com/18F/cg-dashboard/issues/921