### PR TITLE
Fix when buttons have lots of text

### DIFF
--- a/src/css/override_components.scss
+++ b/src/css/override_components.scss
@@ -112,8 +112,9 @@ button,
   display: inline-block;
   font-size: $sans-s3;
   font-weight: 500;
-  height: $grid-4;
+  height: auto;
   margin: $grid-1 $grid-1 $grid-1 0;
+  min-height: $grid-4;
   min-width: 6rem;
   padding: 0 $grid-2;
   text-decoration: none;


### PR DESCRIPTION
By ensuring their height can grow so they can go onto the next line.