### PR TITLE
Change table to default left aligned

### DIFF
--- a/src/css/base/table.scss
+++ b/src/css/base/table.scss
@@ -16,11 +16,7 @@ table {
     border-top: 1px solid;
     padding: .8em 1.25em;
     padding-left: 0;
-    text-align: right;
-
-    &:first-child {
-      text-align: left;
-    }
+    text-align: left;
   }
 
   /* stylelint-disable selector-no-qualifying-type */
@@ -32,6 +28,7 @@ table {
   th:last-child,
   td:last-child {
     padding-right: 0;
+    text-align: right;
   }
 
   thead tr {


### PR DESCRIPTION
The cells in the tables should default to aligning to the left, with
the last child aligning to the right. This works on both old dashboard
UI and tables in the cg-site.