### PR TITLE
Styles for Info components

### DIFF
--- a/src/css/components/all.scss
+++ b/src/css/components/all.scss
@@ -16,6 +16,7 @@
 @import 'logo.scss';
 @import 'header.scss';
 @import 'hexagon.scss';
+@import 'info.scss';
 @import 'loading.scss';
 @import 'form-notification.scss';
 @import 'hex-icon.scss';

--- a/src/css/components/info.scss
+++ b/src/css/components/info.scss
@@ -1,0 +1,7 @@
+
+@import '../override_vars.scss';
+@import '../core.scss';
+
+.info-header {
+  margin-top: $grid-6;
+}


### PR DESCRIPTION
Some of the default styles have rules like `p + h5` which break with the info component because it contains things other than `p`. Using class-based rules avoid that.