### PR TITLE
Add some scroll power to code blocks

### DIFF
--- a/src/css/base/formatted.scss
+++ b/src/css/base/formatted.scss
@@ -17,6 +17,8 @@ pre {
     padding: 0;
     line-height: $lh-body;
     display: inline;
+    overflow: auto;
+    word-wrap: normal;
   }
 }
 


### PR DESCRIPTION
There are a lot of code-blocks in the Operations parts of the documentation that are illegible with word-wrapping. We need to be able to scroll our code-blocks in style. :sunglasses: