### PR TITLE
change text-transform for status to none

### DIFF
--- a/src/css/components/status.scss
+++ b/src/css/components/status.scss
@@ -4,7 +4,7 @@
 @import '../core.scss';
 
 .status {
-  text-transform: capitalize;
+  text-transform: none;
 }
 
 .status-started,

--- a/src/css/components/status.scss
+++ b/src/css/components/status.scss
@@ -3,10 +3,6 @@
 @import '../override_vars.scss';
 @import '../core.scss';
 
-.status {
-  text-transform: none;
-}
-
 .status-started,
 .status-running,
 .status-ok {


### PR DESCRIPTION
Intended to fix this issue, where we have confirmation dialogs with sentences with every word capitalized, which is awkward to read:
https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-5851


This is my first CSS change on the project, so please let me know if this fix isn't right.