### PR TITLE
Add a/b testing to GA

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -4,6 +4,7 @@
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-48605964-34', 'auto');
+  ga('require', 'GTM-NTPP43Q');
   ga('set', 'anonymizeIp', true);
   ga('set', 'forceSSL', true);
   ga('send', 'pageview');


### PR DESCRIPTION
This adds the a/b testing snippet to the GA script for cg-site.

I think in the future we should rip out this analytics.js and put it in the cg-site repo. Or at the very least just add release documentation so we know how to update and release npm package.